### PR TITLE
WIP: support ProForma delta mass notation for individual modifications

### DIFF
--- a/R/fragments-calculate.R
+++ b/R/fragments-calculate.R
@@ -24,7 +24,8 @@
 #' @return The methods with `oject = "missing"` returns a
 #'     `data.frame`.
 #'
-#' @param sequence character() providing a peptide sequence.
+#' @param sequence character() providing a peptide sequence. ProForma delta
+#' masses are supported (e.g. "EM[+15.9949]EVEES[-79.9663]PEK").
 #'
 #' @param type `character` vector of target ions; possible values:
 #'     `c("a", "b", "c", "x", "y", "z")`. Default is `type = c("b",
@@ -63,6 +64,9 @@
 #'
 #' @exportMethod calculateFragments
 #'
+#' @references
+#' [HUPO-PSI ProForma specification](http://www.psidev.info/proforma)
+#'
 #' @examples
 #'
 #' ## calculate fragments for ACE with default modification
@@ -93,6 +97,9 @@
 #'
 #' ## disable neutral loss completely
 #' calculateFragments("PQR", neutralLoss=NULL)
+#'
+#' ## ProForma encoded delta masses
+#' calculateFragments("EM[+15.9949]EVEES[-79.9663]PEK")
 setMethod("calculateFragments", c("character", "missing"),
           function(sequence, type = c("b", "y"), z = 1,
                    modifications = c(C = 57.02146),
@@ -172,14 +179,17 @@ setMethod("calculateFragments", c("character", "missing"),
         message("Modifications used: ", mods)
     }
 
+    clean_sequence <- .proforma_clean_sequences(sequence)[[1]]
+    delta_mass <- .proforma_delta_masses(sequence)[[1]]
+
     ## split peptide sequence into aa
-    fragment.seq <- strsplit(sequence, "")[[1]]
+    fragment.seq <- strsplit(clean_sequence, "")[[1]]
     fn <- length(fragment.seq)
 
     ## calculate cumulative mass starting at the amino-terminus (for a, b, c)
-    amz <- cumsum(aamass[fragment.seq[-fn]])
+    amz <- cumsum(aamass[fragment.seq[-fn]] + delta_mass[-fn])
     ## calculate cumulative mass starting at the carboxyl-terminus (for x, y, z)
-    cmz <- cumsum(aamass[rev(fragment.seq[-1L])])
+    cmz <- cumsum(aamass[rev(fragment.seq[-1L])] + rev(delta_mass[-1L]))
 
     ## calculate fragment mass (amino-terminus)
     tn <- length(amz)
@@ -202,11 +212,11 @@ setMethod("calculateFragments", c("character", "missing"),
     cmz <- cmz + mass["p"]
 
     ## fragment seq (amino-terminus)
-    aseq <- rep(rep(substring(sequence, rep(1L, fn - 1L),
+    aseq <- rep(rep(substring(clean_sequence, rep(1L, fn - 1L),
                               1L:(fn - 1L)), each = zn), nat)
 
     ## fragment seq (carboxyl-terminus)
-    cseq <- rep(rep(rev(substring(sequence, 2L:fn,
+    cseq <- rep(rep(rev(substring(clean_sequence, 2L:fn,
                                   rep(fn, fn - 1L))), each=zn), nct)
 
     ## fragment str (amino-terminus)

--- a/R/proforma-parser.R
+++ b/R/proforma-parser.R
@@ -1,0 +1,72 @@
+#' ProForma parser
+#'
+#' This helper functions provide a basic implementation of the PSI ProForma
+#' notation.
+#'
+#' @author Sebastian Gibb <mail@sebastiangibb.de>
+#'
+#' @references http://www.psidev.info/proforma
+#' @name proforma-parser
+
+#' Remove all modifications
+#'
+#' @name proforma-parser
+#' @param x `character`, ProForma sequence.
+#' @return `character`, a `character` cleaned of all modifications.
+#' @noRd
+#' @examples
+#' .proforma_clean_sequences(
+#'    c("EM[+15.9949]EVEES[+79.9663]PEK",
+#'      "EM[+15.995]EVEES[-18.01]PEK")
+#' )
+.proforma_clean_sequences <- function(x) {
+    gsub(pattern = "\\[[^]]*\\]|<[^>]*>", "", x)
+}
+
+#' Extract delta masses
+#'
+#' @name proforma-parser
+#' @param x `character`, ProForma sequence.
+#' @return `list`, a `list` of `doubles` representing the delta masses for each
+#' sequence.
+#' @noRd
+#' @examples
+#' .proforma_delta_masses(
+#'    c("EM[+15.9949]EVEES[+79.9663]PEK",
+#'      "EM[+15.995]EVEES[-18.01]PEK")
+#' )
+.proforma_delta_masses <- function(x) {
+    rx <- gregexpr(
+        pattern = "(?<=\\[)[GMURX]?:?[+-][0-9.]+(?=\\])",
+        text = x,
+        perl = TRUE
+    )
+    mapply(function(sequence, start, matched_length, n) {
+        if (any(matched_length < 0))
+            return(double(n))
+
+        # add 2 for the surrounding "[" and "]"
+        matched_length2 <- matched_length + 2L
+        n_clean <- n - sum(matched_length2, na.rm = TRUE)
+        masses <- double(n_clean)
+
+        # subtract 2 for the "[" and the previous amino acid position
+        masses[
+            (start -
+             cumsum(c(2L, matched_length2[-length(matched_length2)]) ))
+        ] <- as.double(
+            gsub(
+                "^[GMURX]:",
+                "",
+                substring(sequence, start, start + matched_length - 1L)
+            )
+        )
+        masses
+    },
+        sequence = x,
+        start = rx,
+        matched_length = lapply(rx, attr, "match.length"),
+        n = nchar(x),
+        SIMPLIFY = FALSE, USE.NAMES = FALSE
+    )
+}

--- a/man/calculateFragments.Rd
+++ b/man/calculateFragments.Rd
@@ -16,7 +16,8 @@
 )
 }
 \arguments{
-\item{sequence}{character() providing a peptide sequence.}
+\item{sequence}{character() providing a peptide sequence. ProForma delta
+masses are supported (e.g. "EM\link{+15.9949}EVEES\link{-79.9663}PEK").}
 
 \item{type}{\code{character} vector of target ions; possible values:
 \code{c("a", "b", "c", "x", "y", "z")}. Default is \code{type = c("b", "y")}.}
@@ -98,6 +99,12 @@ calculateFragments("PQR",
 
 ## disable neutral loss completely
 calculateFragments("PQR", neutralLoss=NULL)
+
+## ProForma encoded delta masses
+calculateFragments("EM[+15.9949]EVEES[-79.9663]PEK")
+}
+\references{
+\href{http://www.psidev.info/proforma}{HUPO-PSI ProForma specification}
 }
 \author{
 Sebastian Gibb \href{mailto:mail@sebastiangibb.de}{mail@sebastiangibb.de}

--- a/tests/testthat/test_proforma-parser.R
+++ b/tests/testthat/test_proforma-parser.R
@@ -1,0 +1,42 @@
+test_that("proforma clean sequences works", {
+    expect_identical(
+        .proforma_clean_sequences(
+            c("EM[+15.9949]EVEES[+79.9663]PEK", "EM[+15.995]EVEES[-18.01]PEK")
+        ),
+        c("EMEVEESPEK", "EMEVEESPEK")
+    )
+})
+
+test_that("proforma delta masses without prefixes are supported", {
+    expect_equal(
+        .proforma_delta_masses(
+            c("EMEVEESPEK", "EM[+15.995]EVEESPEK")
+        ),
+        list(
+            rep(0, 10), 
+            c(0, 15.995, 0, 0, 0, 0, 0, 0, 0, 0)
+        )
+    )
+    expect_equal(
+        .proforma_delta_masses(
+            c("EM[+15.9949]EVEES[+79.9663]PEK", "EM[+15.995]EVEES[-18.01]PEK")
+        ),
+        list(
+            c(0, 15.9949, 0, 0, 0, 0, 79.9663, 0, 0, 0),
+            c(0, 15.995, 0, 0, 0, 0, -18.01, 0, 0, 0)
+        )
+    )
+})
+
+test_that("proforma delta masses with prefixes are supported", {
+    expect_equal(
+        .proforma_delta_masses(
+            c("EM[U:+15.9949]EVEES[M:+79.9663]PEK",
+              "EM[X:+15.995]EVEES[R:-18.01]PEK")
+        ),
+        list(
+            c(0, 15.9949, 0, 0, 0, 0, 79.9663, 0, 0, 0),
+            c(0, 15.995, 0, 0, 0, 0, -18.01, 0, 0, 0)
+        )
+    )
+})


### PR DESCRIPTION
This PR is WIP and should solve the issues #14 and #15 . Both ask for individual modifications on a specific amino acid in the peptide sequence. I add a very basic [HUPO-PSI ProForma](https://github.com/HUPO-PSI/ProForma) parser that only supports the delta mass notation.

Problems:
- ProForma delta mass modification will be added to the fixed global modifications given with the argument "modifications".
- The ProForma specification suggests to use CV links (e.g. unimod - our old, never finished package) and is against the use of the "delta mass" notation.

TODOs:
- Documentation.
- Add modification information to the `"seq"` column in the returned `data.frame`.

``` r
calculateFragments("PQR")
#> Modifications used: C=57.02146
#>          mz ion type pos z seq
#> 1  98.06004  b1    b   1 1   P
#> 2 226.11862  b2    b   2 1  PQ
#> 3 175.11895  y1    y   1 1   R
#> 4 303.17753  y2    y   2 1  QR
#> 5 157.10839 y1_   y_   1 1   R
#> 6 285.16697 y2_   y_   2 1  QR
#> 7 286.15098 y2*   y*   2 1  QR
calculateFragments("P[+10]QR")
#> Modifications used: C=57.02146
#>         mz ion type pos z seq
#> 1 108.0600  b1    b   1 1   P
#> 2 236.1186  b2    b   2 1  PQ
#> 3 175.1190  y1    y   1 1   R
#> 4 303.1775  y2    y   2 1  QR
#> 5 157.1084 y1_   y_   1 1   R
#> 6 285.1670 y2_   y_   2 1  QR
#> 7 286.1510 y2*   y*   2 1  QR
```

If we decide to support this notation we may discuss to support the ProForma global modification notation "<MODIFICATION>SEQUENCE" as well (a modification in `<`, `>` is attached in front of the sequence) (and may remove the `"modification"` argument?).