### PR TITLE
plotSpectraPTM correct annotations

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,7 +44,8 @@ Imports:
     BiocGenerics,
     ProtGenerics (>= 1.27.1),
     QFeatures,
-    MsCoreUtils
+    MsCoreUtils,
+    IRanges
 Suggests:
     msdata,
     rpx,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # PSMatch 1.11
 
+## PSMatch 1.11.5
+
+- Correct `plotSpectraPTM` annotations.
+  
 ## PSMatch 1.11.4
 
 - Added `plotSpectraPTM`: a plotting function to visualise

--- a/R/plotSpectra-PTM.R
+++ b/R/plotSpectra-PTM.R
@@ -250,7 +250,7 @@ plotSpectraPTM <- function(x, deltaMz = TRUE, ppm = 20,
     text(mzs, ints, labels = labels, adj = labelAdj, pos = labelPos,
          col = labelCol, cex = labelCex, srt = labelSrt, offset = labelOffset)
 
-    .draw_psmanno(x, mzs, ints, col, labels, peptide_sequence)
+    .build_annotations(x, mzs, ints, col, labels, peptide_sequence)
 
     plot.xy(xy.coords(mzs, ints), type = "h", col = peakCol)
 
@@ -365,12 +365,12 @@ plotSpectraPTM <- function(x, deltaMz = TRUE, ppm = 20,
 ##' @importFrom graphics segments
 ##'
 ##' @noRd
-.draw_psmanno <- function(x,
-                          mzs = mzs,
-                          ints = ints,
-                          col = col,
-                          labels = labels,
-                          peptide_sequence = peptide_sequence) {
+.build_annotations <- function(x,
+                               mzs = mzs,
+                               ints = ints,
+                               col = col,
+                               labels = labels,
+                               peptide_sequence = peptide_sequence) {
   split_seq <- unlist(
     strsplit(
       peptide_sequence,

--- a/R/plotSpectra-PTM.R
+++ b/R/plotSpectra-PTM.R
@@ -235,7 +235,7 @@ plotSpectraPTM <- function(x, deltaMz = TRUE, ppm = 20,
     labels <- labels[[1]]
     wdths <- max(strwidth(labels, cex = labelCex)) / 2
     usr_lim <- par("usr")
-    ylim[2L] <- ylim[2L] + 0.6 * diff(ylim)
+    ylim[2L] <- ylim[2L] + 0.7 * diff(ylim)
     xlim[1L] <- xlim[1L] - wdths
     xlim[2L] <- xlim[2L] + wdths
     plot.window(xlim = xlim, ylim = ylim)

--- a/R/plotSpectra-PTM.R
+++ b/R/plotSpectra-PTM.R
@@ -34,8 +34,9 @@
 ##' @param ylim `numeric(2)` defining the y-axis limits. The range of intensity
 ##'     values are used by default.
 ##'
-##' @param main `character(1)` with the title for the plot. By default the
-##'     spectrum's MS level and retention time (in seconds) is used.
+##' @param main `character(1)` with the title for the each spectrum. By default
+##' `NULL`, if variable modifications are used, the same title is applied on all
+##' plots originating from a common spectrum.
 ##'
 ##' @param col Named `character(4L)`. Colors for the labels, the character names
 ##'     need to be "b", "y", "acxz" and "other", respectively for the b-ions,

--- a/R/plotSpectra-PTM.R
+++ b/R/plotSpectra-PTM.R
@@ -351,17 +351,17 @@ plotSpectraPTM <- function(x, deltaMz = TRUE, ppm = 20,
 
 ##' Annotated sequence fragments split view
 ##'
-##' @param x Spectra object
+##' @param x `Spectra(1L)` object
 ##'
 ##' @param peptide_sequence `character(1L)` The identified peptide sequence
 ##'
-##' @param mzs mz values of peaks
+##' @param mzs `numeric()` mz values of peaks
 ##'
-##' @param ints the intensity values of peaks
+##' @param ints `numeric()` the intensity values of peaks
 ##'
-##' @param labels labels associated to the peaks
+##' @param labels `character()` labels associated to the peaks
 ##' 
-##' @param col The colors of annotations
+##' @param col named `character(4L)` The colors of annotations
 ##'
 ##' @importFrom graphics segments
 ##'

--- a/man/plotSpectraPTM.Rd
+++ b/man/plotSpectraPTM.Rd
@@ -46,8 +46,9 @@ are used by default.}
 \item{ylim}{\code{numeric(2)} defining the y-axis limits. The range of intensity
 values are used by default.}
 
-\item{main}{\code{character(1)} with the title for the plot. By default the
-spectrum's MS level and retention time (in seconds) is used.}
+\item{main}{\code{character(1)} with the title for the each spectrum. By default
+\code{NULL}, if variable modifications are used, the same title is applied on all
+plots originating from a common spectrum.}
 
 \item{col}{Named \code{character(4L)}. Colors for the labels, the character names
 need to be "b", "y", "acxz" and "other", respectively for the b-ions,

--- a/tests/testthat/_snaps/plotSpectraPTM/deltamz-false.svg
+++ b/tests/testthat/_snaps/plotSpectraPTM/deltamz-false.svg
@@ -25,54 +25,54 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpNTcuNjB8NjkxLjIwfDE0LjQwfDUxOC40MA==)'>
-<text x='93.83' y='480.18' text-anchor='middle' style='font-size: 12.00px; fill: #006400; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>a2</text>
-<text x='111.15' y='482.86' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b2</text>
-<text x='146.40' y='464.26' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b3</text>
-<text x='237.35' y='436.13' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b4</text>
-<text x='329.53' y='450.72' text-anchor='middle' style='font-size: 12.00px; fill: #8B0000; font-family: sans;' textLength='12.68px' lengthAdjust='spacingAndGlyphs'>y6</text>
-<text x='352.41' y='475.87' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b6</text>
-<text x='571.40' y='483.90' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='26.70px' lengthAdjust='spacingAndGlyphs'>b10_</text>
-<text x='262.17' y='110.11' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>H</text>
-<text x='284.62' y='110.11' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'>I</text>
-<text x='307.06' y='110.12' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
-<text x='329.51' y='110.11' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='7.33px' lengthAdjust='spacingAndGlyphs'>F</text>
-<text x='351.95' y='110.11' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>E</text>
-<text x='374.40' y='110.12' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
-<text x='396.85' y='110.11' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>D</text>
-<text x='419.29' y='110.12' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>S</text>
-<text x='441.74' y='110.11' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'>I</text>
-<text x='464.18' y='110.12' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
-<text x='486.63' y='110.11' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>R</text>
-<line x1='295.84' y1='105.98' x2='295.84' y2='125.43' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='318.29' y1='105.98' x2='318.29' y2='125.43' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='340.73' y1='105.98' x2='340.73' y2='125.43' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='385.62' y1='105.98' x2='385.62' y2='125.43' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='290.23' y1='135.15' x2='295.84' y2='125.43' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='312.68' y1='135.15' x2='318.29' y2='125.43' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='335.12' y1='135.15' x2='340.73' y2='125.43' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='380.01' y1='135.15' x2='385.62' y2='125.43' style='stroke-width: 1.50; stroke: #00008B;' />
-<text x='287.42' y='145.89' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
-<text x='309.87' y='145.89' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
-<text x='332.32' y='145.89' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
-<text x='377.21' y='145.89' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
-<line x1='363.18' y1='105.98' x2='363.18' y2='86.54' style='stroke-width: 1.50; stroke: #8B0000;' />
-<line x1='368.79' y1='76.82' x2='363.18' y2='86.54' style='stroke-width: 1.50; stroke: #8B0000;' />
-<text x='371.59' y='74.34' text-anchor='middle' style='font-size: 12.00px; fill: #8B0000; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
-<line x1='93.83' y1='499.73' x2='93.83' y2='487.38' style='stroke-width: 0.75; stroke: #006400;' />
-<line x1='111.15' y1='499.73' x2='111.15' y2='490.06' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='146.40' y1='499.73' x2='146.40' y2='471.46' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='237.35' y1='499.73' x2='237.35' y2='443.33' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='329.53' y1='499.73' x2='329.53' y2='457.92' style='stroke-width: 0.75; stroke: #8B0000;' />
-<line x1='352.41' y1='499.73' x2='352.41' y2='483.07' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='368.43' y1='499.73' x2='368.43' y2='493.93' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='437.12' y1='499.73' x2='437.12' y2='479.05' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='458.79' y1='499.73' x2='458.79' y2='348.69' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='526.82' y1='499.73' x2='526.82' y2='490.36' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='571.40' y1='499.73' x2='571.40' y2='491.10' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='584.99' y1='499.73' x2='584.99' y2='208.07' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='614.69' y1='499.73' x2='614.69' y2='464.02' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='643.79' y1='499.73' x2='643.79' y2='300.63' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='654.97' y1='499.73' x2='654.97' y2='493.68' style='stroke-width: 0.75; stroke: #666666;' />
+<text x='93.83' y='480.91' text-anchor='middle' style='font-size: 12.00px; fill: #006400; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>a2</text>
+<text x='111.15' y='483.43' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b2</text>
+<text x='146.40' y='465.92' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b3</text>
+<text x='237.35' y='439.45' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b4</text>
+<text x='329.53' y='453.18' text-anchor='middle' style='font-size: 12.00px; fill: #8B0000; font-family: sans;' textLength='12.68px' lengthAdjust='spacingAndGlyphs'>y6</text>
+<text x='352.41' y='476.85' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b6</text>
+<text x='571.40' y='484.41' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='26.70px' lengthAdjust='spacingAndGlyphs'>b10_</text>
+<text x='262.17' y='133.27' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>H</text>
+<text x='284.62' y='133.27' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'>I</text>
+<text x='307.06' y='133.28' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='329.51' y='133.27' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='7.33px' lengthAdjust='spacingAndGlyphs'>F</text>
+<text x='351.95' y='133.27' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>E</text>
+<text x='374.40' y='133.28' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='396.85' y='133.27' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>D</text>
+<text x='419.29' y='133.28' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>S</text>
+<text x='441.74' y='133.27' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'>I</text>
+<text x='464.18' y='133.28' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='486.63' y='133.27' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>R</text>
+<line x1='295.84' y1='129.15' x2='295.84' y2='147.45' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='318.29' y1='129.15' x2='318.29' y2='147.45' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='340.73' y1='129.15' x2='340.73' y2='147.45' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='385.62' y1='129.15' x2='385.62' y2='147.45' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='290.23' y1='156.60' x2='295.84' y2='147.45' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='312.68' y1='156.60' x2='318.29' y2='147.45' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='335.12' y1='156.60' x2='340.73' y2='147.45' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='380.01' y1='156.60' x2='385.62' y2='147.45' style='stroke-width: 1.50; stroke: #00008B;' />
+<text x='287.42' y='167.33' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='309.87' y='167.33' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='332.32' y='167.33' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='377.21' y='167.33' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<line x1='363.18' y1='129.15' x2='363.18' y2='110.84' style='stroke-width: 1.50; stroke: #8B0000;' />
+<line x1='368.79' y1='101.69' x2='363.18' y2='110.84' style='stroke-width: 1.50; stroke: #8B0000;' />
+<text x='371.59' y='99.22' text-anchor='middle' style='font-size: 12.00px; fill: #8B0000; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<line x1='93.83' y1='499.73' x2='93.83' y2='488.11' style='stroke-width: 0.75; stroke: #006400;' />
+<line x1='111.15' y1='499.73' x2='111.15' y2='490.63' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='146.40' y1='499.73' x2='146.40' y2='473.12' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='237.35' y1='499.73' x2='237.35' y2='446.65' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='329.53' y1='499.73' x2='329.53' y2='460.38' style='stroke-width: 0.75; stroke: #8B0000;' />
+<line x1='352.41' y1='499.73' x2='352.41' y2='484.05' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='368.43' y1='499.73' x2='368.43' y2='494.27' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='437.12' y1='499.73' x2='437.12' y2='480.27' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='458.79' y1='499.73' x2='458.79' y2='357.58' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='526.82' y1='499.73' x2='526.82' y2='490.91' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='571.40' y1='499.73' x2='571.40' y2='491.61' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='584.99' y1='499.73' x2='584.99' y2='225.22' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='614.69' y1='499.73' x2='614.69' y2='466.12' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='643.79' y1='499.73' x2='643.79' y2='312.34' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='654.97' y1='499.73' x2='654.97' y2='494.03' style='stroke-width: 0.75; stroke: #666666;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <line x1='79.51' y1='499.73' x2='691.20' y2='499.73' style='stroke-width: 0.75; stroke: #737373;' />
@@ -137,23 +137,23 @@
 <line x1='660.79' y1='499.73' x2='660.79' y2='504.77' style='stroke-width: 0.75; stroke: #A6A6A6;' />
 <line x1='673.15' y1='499.73' x2='673.15' y2='504.77' style='stroke-width: 0.75; stroke: #A6A6A6;' />
 <line x1='685.52' y1='499.73' x2='685.52' y2='504.77' style='stroke-width: 0.75; stroke: #A6A6A6;' />
-<line x1='57.60' y1='499.73' x2='57.60' y2='208.07' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='499.73' x2='57.60' y2='225.22' style='stroke-width: 0.75;' />
 <line x1='57.60' y1='499.73' x2='47.52' y2='499.73' style='stroke-width: 0.75;' />
-<line x1='57.60' y1='426.82' x2='47.52' y2='426.82' style='stroke-width: 0.75;' />
-<line x1='57.60' y1='353.90' x2='47.52' y2='353.90' style='stroke-width: 0.75;' />
-<line x1='57.60' y1='280.98' x2='47.52' y2='280.98' style='stroke-width: 0.75;' />
-<line x1='57.60' y1='208.07' x2='47.52' y2='208.07' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='431.11' x2='47.52' y2='431.11' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='362.48' x2='47.52' y2='362.48' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='293.85' x2='47.52' y2='293.85' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='225.22' x2='47.52' y2='225.22' style='stroke-width: 0.75;' />
 <text transform='translate(40.32,499.73) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text transform='translate(40.32,426.82) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>25</text>
-<text transform='translate(40.32,353.90) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>50</text>
-<text transform='translate(40.32,280.98) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>75</text>
-<text transform='translate(40.32,208.07) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text transform='translate(40.32,431.11) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text transform='translate(40.32,362.48) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>50</text>
+<text transform='translate(40.32,293.85) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>75</text>
+<text transform='translate(40.32,225.22) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
 <text x='374.40' y='573.12' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='19.34px' lengthAdjust='spacingAndGlyphs'>m/z</text>
 <text transform='translate(11.52,266.40) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='64.70px' lengthAdjust='spacingAndGlyphs'>intensity [%]</text>
 <text x='374.40' y='25.92' text-anchor='middle' style='font-size: 10.20px; font-family: sans;' textLength='340.78px' lengthAdjust='spacingAndGlyphs'>mzspec/testfile.mzML/scan: 1/rt: 2345/charge: 2/sequence: HIGFEGDSIGR</text>
 </g>
 <g clip-path='url(#cpNTcuNjB8NjkxLjIwfDE0LjQwfDUxOC40MA==)'>
-<text transform='translate(596.11,324.73) rotate(-90)' style='font-size: 10.80px; font-family: sans;' textLength='45.35px' lengthAdjust='spacingAndGlyphs'>1.96e+06</text>
+<text transform='translate(596.11,335.03) rotate(-90)' style='font-size: 10.80px; font-family: sans;' textLength='45.35px' lengthAdjust='spacingAndGlyphs'>1.96e+06</text>
 <line x1='57.60' y1='499.73' x2='691.20' y2='499.73' style='stroke-width: 0.75; stroke: #737373;' />
 </g>
 <defs>

--- a/tests/testthat/_snaps/plotSpectraPTM/deltamz-false.svg
+++ b/tests/testthat/_snaps/plotSpectraPTM/deltamz-false.svg
@@ -25,54 +25,54 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpNTcuNjB8NjkxLjIwfDE0LjQwfDUxOC40MA==)'>
-<text x='93.83' y='478.42' text-anchor='middle' style='font-size: 12.00px; fill: #006400; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>a2</text>
-<text x='111.15' y='481.48' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b2</text>
-<text x='146.40' y='460.22' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b3</text>
-<text x='237.35' y='428.08' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b4</text>
-<text x='329.53' y='444.74' text-anchor='middle' style='font-size: 12.00px; fill: #8B0000; font-family: sans;' textLength='12.68px' lengthAdjust='spacingAndGlyphs'>y6</text>
-<text x='352.41' y='473.49' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b6</text>
-<text x='571.40' y='482.67' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='26.70px' lengthAdjust='spacingAndGlyphs'>b10_</text>
-<text x='189.82' y='103.86' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>H</text>
-<text x='226.73' y='103.86' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'>I</text>
-<text x='263.65' y='103.87' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
-<text x='300.57' y='103.86' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='7.33px' lengthAdjust='spacingAndGlyphs'>F</text>
-<text x='337.48' y='103.86' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>E</text>
-<text x='374.40' y='103.87' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
-<text x='411.32' y='103.86' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>D</text>
-<text x='448.23' y='103.87' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>S</text>
-<text x='485.15' y='103.86' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'>I</text>
-<text x='522.07' y='103.87' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
-<text x='558.98' y='103.86' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>R</text>
-<line x1='245.19' y1='99.73' x2='245.19' y2='121.96' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='282.11' y1='99.73' x2='282.11' y2='121.96' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='319.03' y1='99.73' x2='319.03' y2='121.96' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='392.86' y1='99.73' x2='392.86' y2='121.96' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='235.96' y1='121.96' x2='245.19' y2='121.96' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='272.88' y1='121.96' x2='282.11' y2='121.96' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='309.80' y1='121.96' x2='319.03' y2='121.96' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='383.63' y1='121.96' x2='392.86' y2='121.96' style='stroke-width: 1.50; stroke: #00008B;' />
-<text x='240.58' y='132.69' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
-<text x='277.49' y='132.69' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
-<text x='314.41' y='132.69' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
-<text x='388.24' y='132.69' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
-<line x1='355.94' y1='99.73' x2='355.94' y2='77.51' style='stroke-width: 1.50; stroke: #8B0000;' />
-<line x1='365.17' y1='77.51' x2='355.94' y2='77.51' style='stroke-width: 1.50; stroke: #8B0000;' />
-<text x='360.56' y='75.03' text-anchor='middle' style='font-size: 12.00px; fill: #8B0000; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
-<line x1='93.83' y1='499.73' x2='93.83' y2='485.62' style='stroke-width: 0.75; stroke: #006400;' />
-<line x1='111.15' y1='499.73' x2='111.15' y2='488.68' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='146.40' y1='499.73' x2='146.40' y2='467.42' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='237.35' y1='499.73' x2='237.35' y2='435.28' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='329.53' y1='499.73' x2='329.53' y2='451.94' style='stroke-width: 0.75; stroke: #8B0000;' />
-<line x1='352.41' y1='499.73' x2='352.41' y2='480.69' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='368.43' y1='499.73' x2='368.43' y2='493.10' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='437.12' y1='499.73' x2='437.12' y2='476.09' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='458.79' y1='499.73' x2='458.79' y2='327.11' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='526.82' y1='499.73' x2='526.82' y2='489.02' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='571.40' y1='499.73' x2='571.40' y2='489.87' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='584.99' y1='499.73' x2='584.99' y2='166.40' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='614.69' y1='499.73' x2='614.69' y2='458.92' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='643.79' y1='499.73' x2='643.79' y2='272.18' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='654.97' y1='499.73' x2='654.97' y2='492.81' style='stroke-width: 0.75; stroke: #666666;' />
+<text x='93.83' y='480.18' text-anchor='middle' style='font-size: 12.00px; fill: #006400; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>a2</text>
+<text x='111.15' y='482.86' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b2</text>
+<text x='146.40' y='464.26' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b3</text>
+<text x='237.35' y='436.13' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b4</text>
+<text x='329.53' y='450.72' text-anchor='middle' style='font-size: 12.00px; fill: #8B0000; font-family: sans;' textLength='12.68px' lengthAdjust='spacingAndGlyphs'>y6</text>
+<text x='352.41' y='475.87' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b6</text>
+<text x='571.40' y='483.90' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='26.70px' lengthAdjust='spacingAndGlyphs'>b10_</text>
+<text x='262.17' y='110.11' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>H</text>
+<text x='284.62' y='110.11' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'>I</text>
+<text x='307.06' y='110.12' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='329.51' y='110.11' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='7.33px' lengthAdjust='spacingAndGlyphs'>F</text>
+<text x='351.95' y='110.11' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>E</text>
+<text x='374.40' y='110.12' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='396.85' y='110.11' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>D</text>
+<text x='419.29' y='110.12' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>S</text>
+<text x='441.74' y='110.11' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'>I</text>
+<text x='464.18' y='110.12' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='486.63' y='110.11' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>R</text>
+<line x1='295.84' y1='105.98' x2='295.84' y2='125.43' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='318.29' y1='105.98' x2='318.29' y2='125.43' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='340.73' y1='105.98' x2='340.73' y2='125.43' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='385.62' y1='105.98' x2='385.62' y2='125.43' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='290.23' y1='135.15' x2='295.84' y2='125.43' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='312.68' y1='135.15' x2='318.29' y2='125.43' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='335.12' y1='135.15' x2='340.73' y2='125.43' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='380.01' y1='135.15' x2='385.62' y2='125.43' style='stroke-width: 1.50; stroke: #00008B;' />
+<text x='287.42' y='145.89' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='309.87' y='145.89' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='332.32' y='145.89' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='377.21' y='145.89' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<line x1='363.18' y1='105.98' x2='363.18' y2='86.54' style='stroke-width: 1.50; stroke: #8B0000;' />
+<line x1='368.79' y1='76.82' x2='363.18' y2='86.54' style='stroke-width: 1.50; stroke: #8B0000;' />
+<text x='371.59' y='74.34' text-anchor='middle' style='font-size: 12.00px; fill: #8B0000; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<line x1='93.83' y1='499.73' x2='93.83' y2='487.38' style='stroke-width: 0.75; stroke: #006400;' />
+<line x1='111.15' y1='499.73' x2='111.15' y2='490.06' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='146.40' y1='499.73' x2='146.40' y2='471.46' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='237.35' y1='499.73' x2='237.35' y2='443.33' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='329.53' y1='499.73' x2='329.53' y2='457.92' style='stroke-width: 0.75; stroke: #8B0000;' />
+<line x1='352.41' y1='499.73' x2='352.41' y2='483.07' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='368.43' y1='499.73' x2='368.43' y2='493.93' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='437.12' y1='499.73' x2='437.12' y2='479.05' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='458.79' y1='499.73' x2='458.79' y2='348.69' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='526.82' y1='499.73' x2='526.82' y2='490.36' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='571.40' y1='499.73' x2='571.40' y2='491.10' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='584.99' y1='499.73' x2='584.99' y2='208.07' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='614.69' y1='499.73' x2='614.69' y2='464.02' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='643.79' y1='499.73' x2='643.79' y2='300.63' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='654.97' y1='499.73' x2='654.97' y2='493.68' style='stroke-width: 0.75; stroke: #666666;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <line x1='79.51' y1='499.73' x2='691.20' y2='499.73' style='stroke-width: 0.75; stroke: #737373;' />
@@ -137,23 +137,23 @@
 <line x1='660.79' y1='499.73' x2='660.79' y2='504.77' style='stroke-width: 0.75; stroke: #A6A6A6;' />
 <line x1='673.15' y1='499.73' x2='673.15' y2='504.77' style='stroke-width: 0.75; stroke: #A6A6A6;' />
 <line x1='685.52' y1='499.73' x2='685.52' y2='504.77' style='stroke-width: 0.75; stroke: #A6A6A6;' />
-<line x1='57.60' y1='499.73' x2='57.60' y2='166.40' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='499.73' x2='57.60' y2='208.07' style='stroke-width: 0.75;' />
 <line x1='57.60' y1='499.73' x2='47.52' y2='499.73' style='stroke-width: 0.75;' />
-<line x1='57.60' y1='416.40' x2='47.52' y2='416.40' style='stroke-width: 0.75;' />
-<line x1='57.60' y1='333.07' x2='47.52' y2='333.07' style='stroke-width: 0.75;' />
-<line x1='57.60' y1='249.73' x2='47.52' y2='249.73' style='stroke-width: 0.75;' />
-<line x1='57.60' y1='166.40' x2='47.52' y2='166.40' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='426.82' x2='47.52' y2='426.82' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='353.90' x2='47.52' y2='353.90' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='280.98' x2='47.52' y2='280.98' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='208.07' x2='47.52' y2='208.07' style='stroke-width: 0.75;' />
 <text transform='translate(40.32,499.73) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text transform='translate(40.32,416.40) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>25</text>
-<text transform='translate(40.32,333.07) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>50</text>
-<text transform='translate(40.32,249.73) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>75</text>
-<text transform='translate(40.32,166.40) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text transform='translate(40.32,426.82) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text transform='translate(40.32,353.90) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>50</text>
+<text transform='translate(40.32,280.98) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>75</text>
+<text transform='translate(40.32,208.07) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
 <text x='374.40' y='573.12' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='19.34px' lengthAdjust='spacingAndGlyphs'>m/z</text>
 <text transform='translate(11.52,266.40) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='64.70px' lengthAdjust='spacingAndGlyphs'>intensity [%]</text>
-<text x='374.40' y='11.52' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='400.92px' lengthAdjust='spacingAndGlyphs'>mzspec/testfile.mzML/scan: 1/rt: 2345/charge: 2/sequence: HIGFEGDSIGR</text>
+<text x='374.40' y='25.92' text-anchor='middle' style='font-size: 10.20px; font-family: sans;' textLength='340.78px' lengthAdjust='spacingAndGlyphs'>mzspec/testfile.mzML/scan: 1/rt: 2345/charge: 2/sequence: HIGFEGDSIGR</text>
 </g>
 <g clip-path='url(#cpNTcuNjB8NjkxLjIwfDE0LjQwfDUxOC40MA==)'>
-<text transform='translate(596.11,299.73) rotate(-90)' style='font-size: 10.80px; font-family: sans;' textLength='45.35px' lengthAdjust='spacingAndGlyphs'>1.96e+06</text>
+<text transform='translate(596.11,324.73) rotate(-90)' style='font-size: 10.80px; font-family: sans;' textLength='45.35px' lengthAdjust='spacingAndGlyphs'>1.96e+06</text>
 <line x1='57.60' y1='499.73' x2='691.20' y2='499.73' style='stroke-width: 0.75; stroke: #737373;' />
 </g>
 <defs>

--- a/tests/testthat/_snaps/plotSpectraPTM/deltamz-true.svg
+++ b/tests/testthat/_snaps/plotSpectraPTM/deltamz-true.svg
@@ -25,54 +25,54 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpNTcuNjB8NjkxLjIwfDE0LjQwfDQyMi40MA==)'>
-<text x='93.83' y='388.66' text-anchor='middle' style='font-size: 12.00px; fill: #006400; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>a2</text>
-<text x='111.15' y='391.14' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b2</text>
-<text x='146.40' y='373.93' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b3</text>
-<text x='237.35' y='347.91' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b4</text>
-<text x='329.53' y='361.40' text-anchor='middle' style='font-size: 12.00px; fill: #8B0000; font-family: sans;' textLength='12.68px' lengthAdjust='spacingAndGlyphs'>y6</text>
-<text x='352.41' y='384.67' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b6</text>
-<text x='571.40' y='392.10' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='26.70px' lengthAdjust='spacingAndGlyphs'>b10_</text>
-<text x='189.82' y='87.61' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>H</text>
-<text x='226.73' y='87.61' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'>I</text>
-<text x='263.65' y='87.61' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
-<text x='300.57' y='87.61' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='7.33px' lengthAdjust='spacingAndGlyphs'>F</text>
-<text x='337.48' y='87.61' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>E</text>
-<text x='374.40' y='87.61' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
-<text x='411.32' y='87.61' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>D</text>
-<text x='448.23' y='87.61' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>S</text>
-<text x='485.15' y='87.61' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'>I</text>
-<text x='522.07' y='87.61' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
-<text x='558.98' y='87.61' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>R</text>
-<line x1='245.19' y1='83.48' x2='245.19' y2='101.47' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='282.11' y1='83.48' x2='282.11' y2='101.47' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='319.03' y1='83.48' x2='319.03' y2='101.47' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='392.86' y1='83.48' x2='392.86' y2='101.47' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='235.96' y1='101.47' x2='245.19' y2='101.47' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='272.88' y1='101.47' x2='282.11' y2='101.47' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='309.80' y1='101.47' x2='319.03' y2='101.47' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='383.63' y1='101.47' x2='392.86' y2='101.47' style='stroke-width: 1.50; stroke: #00008B;' />
-<text x='240.58' y='112.20' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
-<text x='277.49' y='112.20' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
-<text x='314.41' y='112.20' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
-<text x='388.24' y='112.20' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
-<line x1='355.94' y1='83.48' x2='355.94' y2='65.49' style='stroke-width: 1.50; stroke: #8B0000;' />
-<line x1='365.17' y1='65.49' x2='355.94' y2='65.49' style='stroke-width: 1.50; stroke: #8B0000;' />
-<text x='360.56' y='63.01' text-anchor='middle' style='font-size: 12.00px; fill: #8B0000; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
-<line x1='93.83' y1='407.29' x2='93.83' y2='395.86' style='stroke-width: 0.75; stroke: #006400;' />
-<line x1='111.15' y1='407.29' x2='111.15' y2='398.34' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='146.40' y1='407.29' x2='146.40' y2='381.13' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='237.35' y1='407.29' x2='237.35' y2='355.11' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='329.53' y1='407.29' x2='329.53' y2='368.60' style='stroke-width: 0.75; stroke: #8B0000;' />
-<line x1='352.41' y1='407.29' x2='352.41' y2='391.87' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='368.43' y1='407.29' x2='368.43' y2='401.92' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='437.12' y1='407.29' x2='437.12' y2='388.15' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='458.79' y1='407.29' x2='458.79' y2='267.55' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='526.82' y1='407.29' x2='526.82' y2='398.62' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='571.40' y1='407.29' x2='571.40' y2='399.30' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='584.99' y1='407.29' x2='584.99' y2='137.45' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='614.69' y1='407.29' x2='614.69' y2='374.25' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='643.79' y1='407.29' x2='643.79' y2='223.08' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='654.97' y1='407.29' x2='654.97' y2='401.69' style='stroke-width: 0.75; stroke: #666666;' />
+<text x='93.83' y='390.09' text-anchor='middle' style='font-size: 12.00px; fill: #006400; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>a2</text>
+<text x='111.15' y='392.26' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b2</text>
+<text x='146.40' y='377.20' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b3</text>
+<text x='237.35' y='354.43' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b4</text>
+<text x='329.53' y='366.24' text-anchor='middle' style='font-size: 12.00px; fill: #8B0000; font-family: sans;' textLength='12.68px' lengthAdjust='spacingAndGlyphs'>y6</text>
+<text x='352.41' y='386.60' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b6</text>
+<text x='571.40' y='393.10' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='26.70px' lengthAdjust='spacingAndGlyphs'>b10_</text>
+<text x='262.17' y='92.67' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>H</text>
+<text x='284.62' y='92.67' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'>I</text>
+<text x='307.06' y='92.67' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='329.51' y='92.67' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='7.33px' lengthAdjust='spacingAndGlyphs'>F</text>
+<text x='351.95' y='92.67' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>E</text>
+<text x='374.40' y='92.67' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='396.85' y='92.67' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>D</text>
+<text x='419.29' y='92.67' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>S</text>
+<text x='441.74' y='92.67' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'>I</text>
+<text x='464.18' y='92.67' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='486.63' y='92.67' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>R</text>
+<line x1='295.84' y1='88.54' x2='295.84' y2='104.28' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='318.29' y1='88.54' x2='318.29' y2='104.28' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='340.73' y1='88.54' x2='340.73' y2='104.28' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='385.62' y1='88.54' x2='385.62' y2='104.28' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='290.23' y1='112.15' x2='295.84' y2='104.28' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='312.68' y1='112.15' x2='318.29' y2='104.28' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='335.12' y1='112.15' x2='340.73' y2='104.28' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='380.01' y1='112.15' x2='385.62' y2='104.28' style='stroke-width: 1.50; stroke: #00008B;' />
+<text x='287.42' y='122.89' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='309.87' y='122.89' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='332.32' y='122.89' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='377.21' y='122.89' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<line x1='363.18' y1='88.54' x2='363.18' y2='72.80' style='stroke-width: 1.50; stroke: #8B0000;' />
+<line x1='368.79' y1='64.93' x2='363.18' y2='72.80' style='stroke-width: 1.50; stroke: #8B0000;' />
+<text x='371.59' y='62.45' text-anchor='middle' style='font-size: 12.00px; fill: #8B0000; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<line x1='93.83' y1='407.29' x2='93.83' y2='397.29' style='stroke-width: 0.75; stroke: #006400;' />
+<line x1='111.15' y1='407.29' x2='111.15' y2='399.46' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='146.40' y1='407.29' x2='146.40' y2='384.40' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='237.35' y1='407.29' x2='237.35' y2='361.63' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='329.53' y1='407.29' x2='329.53' y2='373.44' style='stroke-width: 0.75; stroke: #8B0000;' />
+<line x1='352.41' y1='407.29' x2='352.41' y2='393.80' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='368.43' y1='407.29' x2='368.43' y2='402.59' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='437.12' y1='407.29' x2='437.12' y2='390.54' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='458.79' y1='407.29' x2='458.79' y2='285.02' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='526.82' y1='407.29' x2='526.82' y2='399.70' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='571.40' y1='407.29' x2='571.40' y2='400.30' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='584.99' y1='407.29' x2='584.99' y2='171.18' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='614.69' y1='407.29' x2='614.69' y2='378.38' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='643.79' y1='407.29' x2='643.79' y2='246.11' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='654.97' y1='407.29' x2='654.97' y2='402.39' style='stroke-width: 0.75; stroke: #666666;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <line x1='79.51' y1='407.29' x2='691.20' y2='407.29' style='stroke-width: 0.75; stroke: #737373;' />
@@ -137,17 +137,17 @@
 <line x1='660.79' y1='407.29' x2='660.79' y2='411.37' style='stroke-width: 0.75; stroke: #A6A6A6;' />
 <line x1='673.15' y1='407.29' x2='673.15' y2='411.37' style='stroke-width: 0.75; stroke: #A6A6A6;' />
 <line x1='685.52' y1='407.29' x2='685.52' y2='411.37' style='stroke-width: 0.75; stroke: #A6A6A6;' />
-<line x1='57.60' y1='407.29' x2='57.60' y2='137.45' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='407.29' x2='57.60' y2='171.18' style='stroke-width: 0.75;' />
 <line x1='57.60' y1='407.29' x2='49.44' y2='407.29' style='stroke-width: 0.75;' />
-<line x1='57.60' y1='339.83' x2='49.44' y2='339.83' style='stroke-width: 0.75;' />
-<line x1='57.60' y1='272.37' x2='49.44' y2='272.37' style='stroke-width: 0.75;' />
-<line x1='57.60' y1='204.91' x2='49.44' y2='204.91' style='stroke-width: 0.75;' />
-<line x1='57.60' y1='137.45' x2='49.44' y2='137.45' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='348.26' x2='49.44' y2='348.26' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='289.23' x2='49.44' y2='289.23' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='230.21' x2='49.44' y2='230.21' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='171.18' x2='49.44' y2='171.18' style='stroke-width: 0.75;' />
 <text transform='translate(40.32,407.29) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text transform='translate(40.32,339.83) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>25</text>
-<text transform='translate(40.32,272.37) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>50</text>
-<text transform='translate(40.32,204.91) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>75</text>
-<text transform='translate(40.32,137.45) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text transform='translate(40.32,348.26) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text transform='translate(40.32,289.23) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>50</text>
+<text transform='translate(40.32,230.21) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>75</text>
+<text transform='translate(40.32,171.18) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
 </g>
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw0ODAuMDA='>
@@ -159,10 +159,10 @@
 <text transform='translate(11.52,218.40) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='64.70px' lengthAdjust='spacingAndGlyphs'>intensity [%]</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<text x='374.40' y='11.52' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='400.92px' lengthAdjust='spacingAndGlyphs'>mzspec/testfile.mzML/scan: 1/rt: 2345/charge: 2/sequence: HIGFEGDSIGR</text>
+<text x='374.40' y='25.92' text-anchor='middle' style='font-size: 10.20px; font-family: sans;' textLength='340.78px' lengthAdjust='spacingAndGlyphs'>mzspec/testfile.mzML/scan: 1/rt: 2345/charge: 2/sequence: HIGFEGDSIGR</text>
 </g>
 <g clip-path='url(#cpNTcuNjB8NjkxLjIwfDE0LjQwfDQyMi40MA==)'>
-<text transform='translate(596.11,245.38) rotate(-90)' style='font-size: 10.80px; font-family: sans;' textLength='45.35px' lengthAdjust='spacingAndGlyphs'>1.96e+06</text>
+<text transform='translate(596.11,265.62) rotate(-90)' style='font-size: 10.80px; font-family: sans;' textLength='45.35px' lengthAdjust='spacingAndGlyphs'>1.96e+06</text>
 <line x1='57.60' y1='407.29' x2='691.20' y2='407.29' style='stroke-width: 0.75; stroke: #737373;' />
 </g>
 <defs>

--- a/tests/testthat/_snaps/plotSpectraPTM/deltamz-true.svg
+++ b/tests/testthat/_snaps/plotSpectraPTM/deltamz-true.svg
@@ -25,54 +25,54 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpNTcuNjB8NjkxLjIwfDE0LjQwfDQyMi40MA==)'>
-<text x='93.83' y='390.09' text-anchor='middle' style='font-size: 12.00px; fill: #006400; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>a2</text>
-<text x='111.15' y='392.26' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b2</text>
-<text x='146.40' y='377.20' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b3</text>
-<text x='237.35' y='354.43' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b4</text>
-<text x='329.53' y='366.24' text-anchor='middle' style='font-size: 12.00px; fill: #8B0000; font-family: sans;' textLength='12.68px' lengthAdjust='spacingAndGlyphs'>y6</text>
-<text x='352.41' y='386.60' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b6</text>
-<text x='571.40' y='393.10' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='26.70px' lengthAdjust='spacingAndGlyphs'>b10_</text>
-<text x='262.17' y='92.67' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>H</text>
-<text x='284.62' y='92.67' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'>I</text>
-<text x='307.06' y='92.67' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
-<text x='329.51' y='92.67' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='7.33px' lengthAdjust='spacingAndGlyphs'>F</text>
-<text x='351.95' y='92.67' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>E</text>
-<text x='374.40' y='92.67' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
-<text x='396.85' y='92.67' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>D</text>
-<text x='419.29' y='92.67' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>S</text>
-<text x='441.74' y='92.67' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'>I</text>
-<text x='464.18' y='92.67' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
-<text x='486.63' y='92.67' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>R</text>
-<line x1='295.84' y1='88.54' x2='295.84' y2='104.28' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='318.29' y1='88.54' x2='318.29' y2='104.28' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='340.73' y1='88.54' x2='340.73' y2='104.28' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='385.62' y1='88.54' x2='385.62' y2='104.28' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='290.23' y1='112.15' x2='295.84' y2='104.28' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='312.68' y1='112.15' x2='318.29' y2='104.28' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='335.12' y1='112.15' x2='340.73' y2='104.28' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='380.01' y1='112.15' x2='385.62' y2='104.28' style='stroke-width: 1.50; stroke: #00008B;' />
-<text x='287.42' y='122.89' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
-<text x='309.87' y='122.89' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
-<text x='332.32' y='122.89' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
-<text x='377.21' y='122.89' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
-<line x1='363.18' y1='88.54' x2='363.18' y2='72.80' style='stroke-width: 1.50; stroke: #8B0000;' />
-<line x1='368.79' y1='64.93' x2='363.18' y2='72.80' style='stroke-width: 1.50; stroke: #8B0000;' />
-<text x='371.59' y='62.45' text-anchor='middle' style='font-size: 12.00px; fill: #8B0000; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
-<line x1='93.83' y1='407.29' x2='93.83' y2='397.29' style='stroke-width: 0.75; stroke: #006400;' />
-<line x1='111.15' y1='407.29' x2='111.15' y2='399.46' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='146.40' y1='407.29' x2='146.40' y2='384.40' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='237.35' y1='407.29' x2='237.35' y2='361.63' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='329.53' y1='407.29' x2='329.53' y2='373.44' style='stroke-width: 0.75; stroke: #8B0000;' />
-<line x1='352.41' y1='407.29' x2='352.41' y2='393.80' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='368.43' y1='407.29' x2='368.43' y2='402.59' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='437.12' y1='407.29' x2='437.12' y2='390.54' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='458.79' y1='407.29' x2='458.79' y2='285.02' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='526.82' y1='407.29' x2='526.82' y2='399.70' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='571.40' y1='407.29' x2='571.40' y2='400.30' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='584.99' y1='407.29' x2='584.99' y2='171.18' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='614.69' y1='407.29' x2='614.69' y2='378.38' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='643.79' y1='407.29' x2='643.79' y2='246.11' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='654.97' y1='407.29' x2='654.97' y2='402.39' style='stroke-width: 0.75; stroke: #666666;' />
+<text x='93.83' y='390.68' text-anchor='middle' style='font-size: 12.00px; fill: #006400; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>a2</text>
+<text x='111.15' y='392.72' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b2</text>
+<text x='146.40' y='378.55' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b3</text>
+<text x='237.35' y='357.12' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b4</text>
+<text x='329.53' y='368.23' text-anchor='middle' style='font-size: 12.00px; fill: #8B0000; font-family: sans;' textLength='12.68px' lengthAdjust='spacingAndGlyphs'>y6</text>
+<text x='352.41' y='387.39' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b6</text>
+<text x='571.40' y='393.51' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='26.70px' lengthAdjust='spacingAndGlyphs'>b10_</text>
+<text x='262.17' y='111.42' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>H</text>
+<text x='284.62' y='111.42' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'>I</text>
+<text x='307.06' y='111.42' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='329.51' y='111.42' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='7.33px' lengthAdjust='spacingAndGlyphs'>F</text>
+<text x='351.95' y='111.42' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>E</text>
+<text x='374.40' y='111.42' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='396.85' y='111.42' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>D</text>
+<text x='419.29' y='111.42' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>S</text>
+<text x='441.74' y='111.42' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'>I</text>
+<text x='464.18' y='111.42' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='486.63' y='111.42' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>R</text>
+<line x1='295.84' y1='107.29' x2='295.84' y2='122.10' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='318.29' y1='107.29' x2='318.29' y2='122.10' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='340.73' y1='107.29' x2='340.73' y2='122.10' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='385.62' y1='107.29' x2='385.62' y2='122.10' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='290.23' y1='129.51' x2='295.84' y2='122.10' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='312.68' y1='129.51' x2='318.29' y2='122.10' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='335.12' y1='129.51' x2='340.73' y2='122.10' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='380.01' y1='129.51' x2='385.62' y2='122.10' style='stroke-width: 1.50; stroke: #00008B;' />
+<text x='287.42' y='140.25' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='309.87' y='140.25' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='332.32' y='140.25' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='377.21' y='140.25' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<line x1='363.18' y1='107.29' x2='363.18' y2='92.47' style='stroke-width: 1.50; stroke: #8B0000;' />
+<line x1='368.79' y1='85.07' x2='363.18' y2='92.47' style='stroke-width: 1.50; stroke: #8B0000;' />
+<text x='371.59' y='82.59' text-anchor='middle' style='font-size: 12.00px; fill: #8B0000; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<line x1='93.83' y1='407.29' x2='93.83' y2='397.88' style='stroke-width: 0.75; stroke: #006400;' />
+<line x1='111.15' y1='407.29' x2='111.15' y2='399.92' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='146.40' y1='407.29' x2='146.40' y2='385.75' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='237.35' y1='407.29' x2='237.35' y2='364.32' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='329.53' y1='407.29' x2='329.53' y2='375.43' style='stroke-width: 0.75; stroke: #8B0000;' />
+<line x1='352.41' y1='407.29' x2='352.41' y2='394.59' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='368.43' y1='407.29' x2='368.43' y2='402.87' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='437.12' y1='407.29' x2='437.12' y2='391.53' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='458.79' y1='407.29' x2='458.79' y2='292.21' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='526.82' y1='407.29' x2='526.82' y2='400.15' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='571.40' y1='407.29' x2='571.40' y2='400.71' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='584.99' y1='407.29' x2='584.99' y2='185.07' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='614.69' y1='407.29' x2='614.69' y2='380.08' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='643.79' y1='407.29' x2='643.79' y2='255.59' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='654.97' y1='407.29' x2='654.97' y2='402.67' style='stroke-width: 0.75; stroke: #666666;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <line x1='79.51' y1='407.29' x2='691.20' y2='407.29' style='stroke-width: 0.75; stroke: #737373;' />
@@ -137,17 +137,17 @@
 <line x1='660.79' y1='407.29' x2='660.79' y2='411.37' style='stroke-width: 0.75; stroke: #A6A6A6;' />
 <line x1='673.15' y1='407.29' x2='673.15' y2='411.37' style='stroke-width: 0.75; stroke: #A6A6A6;' />
 <line x1='685.52' y1='407.29' x2='685.52' y2='411.37' style='stroke-width: 0.75; stroke: #A6A6A6;' />
-<line x1='57.60' y1='407.29' x2='57.60' y2='171.18' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='407.29' x2='57.60' y2='185.07' style='stroke-width: 0.75;' />
 <line x1='57.60' y1='407.29' x2='49.44' y2='407.29' style='stroke-width: 0.75;' />
-<line x1='57.60' y1='348.26' x2='49.44' y2='348.26' style='stroke-width: 0.75;' />
-<line x1='57.60' y1='289.23' x2='49.44' y2='289.23' style='stroke-width: 0.75;' />
-<line x1='57.60' y1='230.21' x2='49.44' y2='230.21' style='stroke-width: 0.75;' />
-<line x1='57.60' y1='171.18' x2='49.44' y2='171.18' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='351.73' x2='49.44' y2='351.73' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='296.18' x2='49.44' y2='296.18' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='240.62' x2='49.44' y2='240.62' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='185.07' x2='49.44' y2='185.07' style='stroke-width: 0.75;' />
 <text transform='translate(40.32,407.29) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text transform='translate(40.32,348.26) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>25</text>
-<text transform='translate(40.32,289.23) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>50</text>
-<text transform='translate(40.32,230.21) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>75</text>
-<text transform='translate(40.32,171.18) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text transform='translate(40.32,351.73) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text transform='translate(40.32,296.18) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>50</text>
+<text transform='translate(40.32,240.62) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>75</text>
+<text transform='translate(40.32,185.07) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
 </g>
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw0ODAuMDA='>
@@ -162,7 +162,7 @@
 <text x='374.40' y='25.92' text-anchor='middle' style='font-size: 10.20px; font-family: sans;' textLength='340.78px' lengthAdjust='spacingAndGlyphs'>mzspec/testfile.mzML/scan: 1/rt: 2345/charge: 2/sequence: HIGFEGDSIGR</text>
 </g>
 <g clip-path='url(#cpNTcuNjB8NjkxLjIwfDE0LjQwfDQyMi40MA==)'>
-<text transform='translate(596.11,265.62) rotate(-90)' style='font-size: 10.80px; font-family: sans;' textLength='45.35px' lengthAdjust='spacingAndGlyphs'>1.96e+06</text>
+<text transform='translate(596.11,273.96) rotate(-90)' style='font-size: 10.80px; font-family: sans;' textLength='45.35px' lengthAdjust='spacingAndGlyphs'>1.96e+06</text>
 <line x1='57.60' y1='407.29' x2='691.20' y2='407.29' style='stroke-width: 0.75; stroke: #737373;' />
 </g>
 <defs>

--- a/tests/testthat/_snaps/plotSpectraPTM/diff-col.svg
+++ b/tests/testthat/_snaps/plotSpectraPTM/diff-col.svg
@@ -25,54 +25,54 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpNTcuNjB8NjkxLjIwfDE0LjQwfDUxOC40MA==)'>
-<text x='93.83' y='478.42' text-anchor='middle' style='font-size: 12.00px; fill: #FFA500; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>a2</text>
-<text x='111.15' y='481.48' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b2</text>
-<text x='146.40' y='460.22' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b3</text>
-<text x='237.35' y='428.08' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b4</text>
-<text x='329.53' y='444.74' text-anchor='middle' style='font-size: 12.00px; fill: #FF0000; font-family: sans;' textLength='12.68px' lengthAdjust='spacingAndGlyphs'>y6</text>
-<text x='352.41' y='473.49' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b6</text>
-<text x='571.40' y='482.67' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='26.70px' lengthAdjust='spacingAndGlyphs'>b10_</text>
-<text x='189.82' y='103.86' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>H</text>
-<text x='226.73' y='103.86' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'>I</text>
-<text x='263.65' y='103.87' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
-<text x='300.57' y='103.86' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='7.33px' lengthAdjust='spacingAndGlyphs'>F</text>
-<text x='337.48' y='103.86' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>E</text>
-<text x='374.40' y='103.87' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
-<text x='411.32' y='103.86' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>D</text>
-<text x='448.23' y='103.87' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>S</text>
-<text x='485.15' y='103.86' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'>I</text>
-<text x='522.07' y='103.87' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
-<text x='558.98' y='103.86' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>R</text>
-<line x1='245.19' y1='99.73' x2='245.19' y2='121.96' style='stroke-width: 1.50; stroke: #0000FF;' />
-<line x1='282.11' y1='99.73' x2='282.11' y2='121.96' style='stroke-width: 1.50; stroke: #0000FF;' />
-<line x1='319.03' y1='99.73' x2='319.03' y2='121.96' style='stroke-width: 1.50; stroke: #0000FF;' />
-<line x1='392.86' y1='99.73' x2='392.86' y2='121.96' style='stroke-width: 1.50; stroke: #0000FF;' />
-<line x1='235.96' y1='121.96' x2='245.19' y2='121.96' style='stroke-width: 1.50; stroke: #0000FF;' />
-<line x1='272.88' y1='121.96' x2='282.11' y2='121.96' style='stroke-width: 1.50; stroke: #0000FF;' />
-<line x1='309.80' y1='121.96' x2='319.03' y2='121.96' style='stroke-width: 1.50; stroke: #0000FF;' />
-<line x1='383.63' y1='121.96' x2='392.86' y2='121.96' style='stroke-width: 1.50; stroke: #0000FF;' />
-<text x='240.58' y='132.69' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
-<text x='277.49' y='132.69' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
-<text x='314.41' y='132.69' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
-<text x='388.24' y='132.69' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
-<line x1='355.94' y1='99.73' x2='355.94' y2='77.51' style='stroke-width: 1.50; stroke: #FF0000;' />
-<line x1='365.17' y1='77.51' x2='355.94' y2='77.51' style='stroke-width: 1.50; stroke: #FF0000;' />
-<text x='360.56' y='75.03' text-anchor='middle' style='font-size: 12.00px; fill: #FF0000; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
-<line x1='93.83' y1='499.73' x2='93.83' y2='485.62' style='stroke-width: 0.75; stroke: #FFA500;' />
-<line x1='111.15' y1='499.73' x2='111.15' y2='488.68' style='stroke-width: 0.75; stroke: #0000FF;' />
-<line x1='146.40' y1='499.73' x2='146.40' y2='467.42' style='stroke-width: 0.75; stroke: #0000FF;' />
-<line x1='237.35' y1='499.73' x2='237.35' y2='435.28' style='stroke-width: 0.75; stroke: #0000FF;' />
-<line x1='329.53' y1='499.73' x2='329.53' y2='451.94' style='stroke-width: 0.75; stroke: #FF0000;' />
-<line x1='352.41' y1='499.73' x2='352.41' y2='480.69' style='stroke-width: 0.75; stroke: #0000FF;' />
-<line x1='368.43' y1='499.73' x2='368.43' y2='493.10' style='stroke-width: 0.75; stroke: #EE82EE;' />
-<line x1='437.12' y1='499.73' x2='437.12' y2='476.09' style='stroke-width: 0.75; stroke: #EE82EE;' />
-<line x1='458.79' y1='499.73' x2='458.79' y2='327.11' style='stroke-width: 0.75; stroke: #EE82EE;' />
-<line x1='526.82' y1='499.73' x2='526.82' y2='489.02' style='stroke-width: 0.75; stroke: #EE82EE;' />
-<line x1='571.40' y1='499.73' x2='571.40' y2='489.87' style='stroke-width: 0.75; stroke: #0000FF;' />
-<line x1='584.99' y1='499.73' x2='584.99' y2='166.40' style='stroke-width: 0.75; stroke: #EE82EE;' />
-<line x1='614.69' y1='499.73' x2='614.69' y2='458.92' style='stroke-width: 0.75; stroke: #EE82EE;' />
-<line x1='643.79' y1='499.73' x2='643.79' y2='272.18' style='stroke-width: 0.75; stroke: #EE82EE;' />
-<line x1='654.97' y1='499.73' x2='654.97' y2='492.81' style='stroke-width: 0.75; stroke: #EE82EE;' />
+<text x='93.83' y='480.18' text-anchor='middle' style='font-size: 12.00px; fill: #FFA500; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>a2</text>
+<text x='111.15' y='482.86' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b2</text>
+<text x='146.40' y='464.26' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b3</text>
+<text x='237.35' y='436.13' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b4</text>
+<text x='329.53' y='450.72' text-anchor='middle' style='font-size: 12.00px; fill: #FF0000; font-family: sans;' textLength='12.68px' lengthAdjust='spacingAndGlyphs'>y6</text>
+<text x='352.41' y='475.87' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b6</text>
+<text x='571.40' y='483.90' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='26.70px' lengthAdjust='spacingAndGlyphs'>b10_</text>
+<text x='262.17' y='110.11' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>H</text>
+<text x='284.62' y='110.11' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'>I</text>
+<text x='307.06' y='110.12' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='329.51' y='110.11' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='7.33px' lengthAdjust='spacingAndGlyphs'>F</text>
+<text x='351.95' y='110.11' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>E</text>
+<text x='374.40' y='110.12' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='396.85' y='110.11' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>D</text>
+<text x='419.29' y='110.12' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>S</text>
+<text x='441.74' y='110.11' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'>I</text>
+<text x='464.18' y='110.12' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='486.63' y='110.11' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>R</text>
+<line x1='295.84' y1='105.98' x2='295.84' y2='125.43' style='stroke-width: 1.50; stroke: #0000FF;' />
+<line x1='318.29' y1='105.98' x2='318.29' y2='125.43' style='stroke-width: 1.50; stroke: #0000FF;' />
+<line x1='340.73' y1='105.98' x2='340.73' y2='125.43' style='stroke-width: 1.50; stroke: #0000FF;' />
+<line x1='385.62' y1='105.98' x2='385.62' y2='125.43' style='stroke-width: 1.50; stroke: #0000FF;' />
+<line x1='290.23' y1='135.15' x2='295.84' y2='125.43' style='stroke-width: 1.50; stroke: #0000FF;' />
+<line x1='312.68' y1='135.15' x2='318.29' y2='125.43' style='stroke-width: 1.50; stroke: #0000FF;' />
+<line x1='335.12' y1='135.15' x2='340.73' y2='125.43' style='stroke-width: 1.50; stroke: #0000FF;' />
+<line x1='380.01' y1='135.15' x2='385.62' y2='125.43' style='stroke-width: 1.50; stroke: #0000FF;' />
+<text x='287.42' y='145.89' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='309.87' y='145.89' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='332.32' y='145.89' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='377.21' y='145.89' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<line x1='363.18' y1='105.98' x2='363.18' y2='86.54' style='stroke-width: 1.50; stroke: #FF0000;' />
+<line x1='368.79' y1='76.82' x2='363.18' y2='86.54' style='stroke-width: 1.50; stroke: #FF0000;' />
+<text x='371.59' y='74.34' text-anchor='middle' style='font-size: 12.00px; fill: #FF0000; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<line x1='93.83' y1='499.73' x2='93.83' y2='487.38' style='stroke-width: 0.75; stroke: #FFA500;' />
+<line x1='111.15' y1='499.73' x2='111.15' y2='490.06' style='stroke-width: 0.75; stroke: #0000FF;' />
+<line x1='146.40' y1='499.73' x2='146.40' y2='471.46' style='stroke-width: 0.75; stroke: #0000FF;' />
+<line x1='237.35' y1='499.73' x2='237.35' y2='443.33' style='stroke-width: 0.75; stroke: #0000FF;' />
+<line x1='329.53' y1='499.73' x2='329.53' y2='457.92' style='stroke-width: 0.75; stroke: #FF0000;' />
+<line x1='352.41' y1='499.73' x2='352.41' y2='483.07' style='stroke-width: 0.75; stroke: #0000FF;' />
+<line x1='368.43' y1='499.73' x2='368.43' y2='493.93' style='stroke-width: 0.75; stroke: #EE82EE;' />
+<line x1='437.12' y1='499.73' x2='437.12' y2='479.05' style='stroke-width: 0.75; stroke: #EE82EE;' />
+<line x1='458.79' y1='499.73' x2='458.79' y2='348.69' style='stroke-width: 0.75; stroke: #EE82EE;' />
+<line x1='526.82' y1='499.73' x2='526.82' y2='490.36' style='stroke-width: 0.75; stroke: #EE82EE;' />
+<line x1='571.40' y1='499.73' x2='571.40' y2='491.10' style='stroke-width: 0.75; stroke: #0000FF;' />
+<line x1='584.99' y1='499.73' x2='584.99' y2='208.07' style='stroke-width: 0.75; stroke: #EE82EE;' />
+<line x1='614.69' y1='499.73' x2='614.69' y2='464.02' style='stroke-width: 0.75; stroke: #EE82EE;' />
+<line x1='643.79' y1='499.73' x2='643.79' y2='300.63' style='stroke-width: 0.75; stroke: #EE82EE;' />
+<line x1='654.97' y1='499.73' x2='654.97' y2='493.68' style='stroke-width: 0.75; stroke: #EE82EE;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <line x1='79.51' y1='499.73' x2='691.20' y2='499.73' style='stroke-width: 0.75; stroke: #737373;' />
@@ -137,23 +137,23 @@
 <line x1='660.79' y1='499.73' x2='660.79' y2='504.77' style='stroke-width: 0.75; stroke: #A6A6A6;' />
 <line x1='673.15' y1='499.73' x2='673.15' y2='504.77' style='stroke-width: 0.75; stroke: #A6A6A6;' />
 <line x1='685.52' y1='499.73' x2='685.52' y2='504.77' style='stroke-width: 0.75; stroke: #A6A6A6;' />
-<line x1='57.60' y1='499.73' x2='57.60' y2='166.40' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='499.73' x2='57.60' y2='208.07' style='stroke-width: 0.75;' />
 <line x1='57.60' y1='499.73' x2='47.52' y2='499.73' style='stroke-width: 0.75;' />
-<line x1='57.60' y1='416.40' x2='47.52' y2='416.40' style='stroke-width: 0.75;' />
-<line x1='57.60' y1='333.07' x2='47.52' y2='333.07' style='stroke-width: 0.75;' />
-<line x1='57.60' y1='249.73' x2='47.52' y2='249.73' style='stroke-width: 0.75;' />
-<line x1='57.60' y1='166.40' x2='47.52' y2='166.40' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='426.82' x2='47.52' y2='426.82' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='353.90' x2='47.52' y2='353.90' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='280.98' x2='47.52' y2='280.98' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='208.07' x2='47.52' y2='208.07' style='stroke-width: 0.75;' />
 <text transform='translate(40.32,499.73) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text transform='translate(40.32,416.40) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>25</text>
-<text transform='translate(40.32,333.07) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>50</text>
-<text transform='translate(40.32,249.73) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>75</text>
-<text transform='translate(40.32,166.40) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text transform='translate(40.32,426.82) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text transform='translate(40.32,353.90) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>50</text>
+<text transform='translate(40.32,280.98) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>75</text>
+<text transform='translate(40.32,208.07) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
 <text x='374.40' y='573.12' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='19.34px' lengthAdjust='spacingAndGlyphs'>m/z</text>
 <text transform='translate(11.52,266.40) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='64.70px' lengthAdjust='spacingAndGlyphs'>intensity [%]</text>
-<text x='374.40' y='11.52' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='400.92px' lengthAdjust='spacingAndGlyphs'>mzspec/testfile.mzML/scan: 1/rt: 2345/charge: 2/sequence: HIGFEGDSIGR</text>
+<text x='374.40' y='25.92' text-anchor='middle' style='font-size: 10.20px; font-family: sans;' textLength='340.78px' lengthAdjust='spacingAndGlyphs'>mzspec/testfile.mzML/scan: 1/rt: 2345/charge: 2/sequence: HIGFEGDSIGR</text>
 </g>
 <g clip-path='url(#cpNTcuNjB8NjkxLjIwfDE0LjQwfDUxOC40MA==)'>
-<text transform='translate(596.11,299.73) rotate(-90)' style='font-size: 10.80px; font-family: sans;' textLength='45.35px' lengthAdjust='spacingAndGlyphs'>1.96e+06</text>
+<text transform='translate(596.11,324.73) rotate(-90)' style='font-size: 10.80px; font-family: sans;' textLength='45.35px' lengthAdjust='spacingAndGlyphs'>1.96e+06</text>
 <line x1='57.60' y1='499.73' x2='691.20' y2='499.73' style='stroke-width: 0.75; stroke: #737373;' />
 </g>
 <defs>

--- a/tests/testthat/_snaps/plotSpectraPTM/diff-col.svg
+++ b/tests/testthat/_snaps/plotSpectraPTM/diff-col.svg
@@ -25,54 +25,54 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpNTcuNjB8NjkxLjIwfDE0LjQwfDUxOC40MA==)'>
-<text x='93.83' y='480.18' text-anchor='middle' style='font-size: 12.00px; fill: #FFA500; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>a2</text>
-<text x='111.15' y='482.86' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b2</text>
-<text x='146.40' y='464.26' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b3</text>
-<text x='237.35' y='436.13' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b4</text>
-<text x='329.53' y='450.72' text-anchor='middle' style='font-size: 12.00px; fill: #FF0000; font-family: sans;' textLength='12.68px' lengthAdjust='spacingAndGlyphs'>y6</text>
-<text x='352.41' y='475.87' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b6</text>
-<text x='571.40' y='483.90' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='26.70px' lengthAdjust='spacingAndGlyphs'>b10_</text>
-<text x='262.17' y='110.11' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>H</text>
-<text x='284.62' y='110.11' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'>I</text>
-<text x='307.06' y='110.12' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
-<text x='329.51' y='110.11' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='7.33px' lengthAdjust='spacingAndGlyphs'>F</text>
-<text x='351.95' y='110.11' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>E</text>
-<text x='374.40' y='110.12' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
-<text x='396.85' y='110.11' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>D</text>
-<text x='419.29' y='110.12' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>S</text>
-<text x='441.74' y='110.11' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'>I</text>
-<text x='464.18' y='110.12' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
-<text x='486.63' y='110.11' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>R</text>
-<line x1='295.84' y1='105.98' x2='295.84' y2='125.43' style='stroke-width: 1.50; stroke: #0000FF;' />
-<line x1='318.29' y1='105.98' x2='318.29' y2='125.43' style='stroke-width: 1.50; stroke: #0000FF;' />
-<line x1='340.73' y1='105.98' x2='340.73' y2='125.43' style='stroke-width: 1.50; stroke: #0000FF;' />
-<line x1='385.62' y1='105.98' x2='385.62' y2='125.43' style='stroke-width: 1.50; stroke: #0000FF;' />
-<line x1='290.23' y1='135.15' x2='295.84' y2='125.43' style='stroke-width: 1.50; stroke: #0000FF;' />
-<line x1='312.68' y1='135.15' x2='318.29' y2='125.43' style='stroke-width: 1.50; stroke: #0000FF;' />
-<line x1='335.12' y1='135.15' x2='340.73' y2='125.43' style='stroke-width: 1.50; stroke: #0000FF;' />
-<line x1='380.01' y1='135.15' x2='385.62' y2='125.43' style='stroke-width: 1.50; stroke: #0000FF;' />
-<text x='287.42' y='145.89' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
-<text x='309.87' y='145.89' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
-<text x='332.32' y='145.89' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
-<text x='377.21' y='145.89' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
-<line x1='363.18' y1='105.98' x2='363.18' y2='86.54' style='stroke-width: 1.50; stroke: #FF0000;' />
-<line x1='368.79' y1='76.82' x2='363.18' y2='86.54' style='stroke-width: 1.50; stroke: #FF0000;' />
-<text x='371.59' y='74.34' text-anchor='middle' style='font-size: 12.00px; fill: #FF0000; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
-<line x1='93.83' y1='499.73' x2='93.83' y2='487.38' style='stroke-width: 0.75; stroke: #FFA500;' />
-<line x1='111.15' y1='499.73' x2='111.15' y2='490.06' style='stroke-width: 0.75; stroke: #0000FF;' />
-<line x1='146.40' y1='499.73' x2='146.40' y2='471.46' style='stroke-width: 0.75; stroke: #0000FF;' />
-<line x1='237.35' y1='499.73' x2='237.35' y2='443.33' style='stroke-width: 0.75; stroke: #0000FF;' />
-<line x1='329.53' y1='499.73' x2='329.53' y2='457.92' style='stroke-width: 0.75; stroke: #FF0000;' />
-<line x1='352.41' y1='499.73' x2='352.41' y2='483.07' style='stroke-width: 0.75; stroke: #0000FF;' />
-<line x1='368.43' y1='499.73' x2='368.43' y2='493.93' style='stroke-width: 0.75; stroke: #EE82EE;' />
-<line x1='437.12' y1='499.73' x2='437.12' y2='479.05' style='stroke-width: 0.75; stroke: #EE82EE;' />
-<line x1='458.79' y1='499.73' x2='458.79' y2='348.69' style='stroke-width: 0.75; stroke: #EE82EE;' />
-<line x1='526.82' y1='499.73' x2='526.82' y2='490.36' style='stroke-width: 0.75; stroke: #EE82EE;' />
-<line x1='571.40' y1='499.73' x2='571.40' y2='491.10' style='stroke-width: 0.75; stroke: #0000FF;' />
-<line x1='584.99' y1='499.73' x2='584.99' y2='208.07' style='stroke-width: 0.75; stroke: #EE82EE;' />
-<line x1='614.69' y1='499.73' x2='614.69' y2='464.02' style='stroke-width: 0.75; stroke: #EE82EE;' />
-<line x1='643.79' y1='499.73' x2='643.79' y2='300.63' style='stroke-width: 0.75; stroke: #EE82EE;' />
-<line x1='654.97' y1='499.73' x2='654.97' y2='493.68' style='stroke-width: 0.75; stroke: #EE82EE;' />
+<text x='93.83' y='480.91' text-anchor='middle' style='font-size: 12.00px; fill: #FFA500; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>a2</text>
+<text x='111.15' y='483.43' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b2</text>
+<text x='146.40' y='465.92' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b3</text>
+<text x='237.35' y='439.45' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b4</text>
+<text x='329.53' y='453.18' text-anchor='middle' style='font-size: 12.00px; fill: #FF0000; font-family: sans;' textLength='12.68px' lengthAdjust='spacingAndGlyphs'>y6</text>
+<text x='352.41' y='476.85' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b6</text>
+<text x='571.40' y='484.41' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='26.70px' lengthAdjust='spacingAndGlyphs'>b10_</text>
+<text x='262.17' y='133.27' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>H</text>
+<text x='284.62' y='133.27' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'>I</text>
+<text x='307.06' y='133.28' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='329.51' y='133.27' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='7.33px' lengthAdjust='spacingAndGlyphs'>F</text>
+<text x='351.95' y='133.27' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>E</text>
+<text x='374.40' y='133.28' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='396.85' y='133.27' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>D</text>
+<text x='419.29' y='133.28' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>S</text>
+<text x='441.74' y='133.27' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'>I</text>
+<text x='464.18' y='133.28' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='486.63' y='133.27' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>R</text>
+<line x1='295.84' y1='129.15' x2='295.84' y2='147.45' style='stroke-width: 1.50; stroke: #0000FF;' />
+<line x1='318.29' y1='129.15' x2='318.29' y2='147.45' style='stroke-width: 1.50; stroke: #0000FF;' />
+<line x1='340.73' y1='129.15' x2='340.73' y2='147.45' style='stroke-width: 1.50; stroke: #0000FF;' />
+<line x1='385.62' y1='129.15' x2='385.62' y2='147.45' style='stroke-width: 1.50; stroke: #0000FF;' />
+<line x1='290.23' y1='156.60' x2='295.84' y2='147.45' style='stroke-width: 1.50; stroke: #0000FF;' />
+<line x1='312.68' y1='156.60' x2='318.29' y2='147.45' style='stroke-width: 1.50; stroke: #0000FF;' />
+<line x1='335.12' y1='156.60' x2='340.73' y2='147.45' style='stroke-width: 1.50; stroke: #0000FF;' />
+<line x1='380.01' y1='156.60' x2='385.62' y2='147.45' style='stroke-width: 1.50; stroke: #0000FF;' />
+<text x='287.42' y='167.33' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='309.87' y='167.33' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='332.32' y='167.33' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='377.21' y='167.33' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<line x1='363.18' y1='129.15' x2='363.18' y2='110.84' style='stroke-width: 1.50; stroke: #FF0000;' />
+<line x1='368.79' y1='101.69' x2='363.18' y2='110.84' style='stroke-width: 1.50; stroke: #FF0000;' />
+<text x='371.59' y='99.22' text-anchor='middle' style='font-size: 12.00px; fill: #FF0000; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<line x1='93.83' y1='499.73' x2='93.83' y2='488.11' style='stroke-width: 0.75; stroke: #FFA500;' />
+<line x1='111.15' y1='499.73' x2='111.15' y2='490.63' style='stroke-width: 0.75; stroke: #0000FF;' />
+<line x1='146.40' y1='499.73' x2='146.40' y2='473.12' style='stroke-width: 0.75; stroke: #0000FF;' />
+<line x1='237.35' y1='499.73' x2='237.35' y2='446.65' style='stroke-width: 0.75; stroke: #0000FF;' />
+<line x1='329.53' y1='499.73' x2='329.53' y2='460.38' style='stroke-width: 0.75; stroke: #FF0000;' />
+<line x1='352.41' y1='499.73' x2='352.41' y2='484.05' style='stroke-width: 0.75; stroke: #0000FF;' />
+<line x1='368.43' y1='499.73' x2='368.43' y2='494.27' style='stroke-width: 0.75; stroke: #EE82EE;' />
+<line x1='437.12' y1='499.73' x2='437.12' y2='480.27' style='stroke-width: 0.75; stroke: #EE82EE;' />
+<line x1='458.79' y1='499.73' x2='458.79' y2='357.58' style='stroke-width: 0.75; stroke: #EE82EE;' />
+<line x1='526.82' y1='499.73' x2='526.82' y2='490.91' style='stroke-width: 0.75; stroke: #EE82EE;' />
+<line x1='571.40' y1='499.73' x2='571.40' y2='491.61' style='stroke-width: 0.75; stroke: #0000FF;' />
+<line x1='584.99' y1='499.73' x2='584.99' y2='225.22' style='stroke-width: 0.75; stroke: #EE82EE;' />
+<line x1='614.69' y1='499.73' x2='614.69' y2='466.12' style='stroke-width: 0.75; stroke: #EE82EE;' />
+<line x1='643.79' y1='499.73' x2='643.79' y2='312.34' style='stroke-width: 0.75; stroke: #EE82EE;' />
+<line x1='654.97' y1='499.73' x2='654.97' y2='494.03' style='stroke-width: 0.75; stroke: #EE82EE;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <line x1='79.51' y1='499.73' x2='691.20' y2='499.73' style='stroke-width: 0.75; stroke: #737373;' />
@@ -137,23 +137,23 @@
 <line x1='660.79' y1='499.73' x2='660.79' y2='504.77' style='stroke-width: 0.75; stroke: #A6A6A6;' />
 <line x1='673.15' y1='499.73' x2='673.15' y2='504.77' style='stroke-width: 0.75; stroke: #A6A6A6;' />
 <line x1='685.52' y1='499.73' x2='685.52' y2='504.77' style='stroke-width: 0.75; stroke: #A6A6A6;' />
-<line x1='57.60' y1='499.73' x2='57.60' y2='208.07' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='499.73' x2='57.60' y2='225.22' style='stroke-width: 0.75;' />
 <line x1='57.60' y1='499.73' x2='47.52' y2='499.73' style='stroke-width: 0.75;' />
-<line x1='57.60' y1='426.82' x2='47.52' y2='426.82' style='stroke-width: 0.75;' />
-<line x1='57.60' y1='353.90' x2='47.52' y2='353.90' style='stroke-width: 0.75;' />
-<line x1='57.60' y1='280.98' x2='47.52' y2='280.98' style='stroke-width: 0.75;' />
-<line x1='57.60' y1='208.07' x2='47.52' y2='208.07' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='431.11' x2='47.52' y2='431.11' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='362.48' x2='47.52' y2='362.48' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='293.85' x2='47.52' y2='293.85' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='225.22' x2='47.52' y2='225.22' style='stroke-width: 0.75;' />
 <text transform='translate(40.32,499.73) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text transform='translate(40.32,426.82) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>25</text>
-<text transform='translate(40.32,353.90) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>50</text>
-<text transform='translate(40.32,280.98) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>75</text>
-<text transform='translate(40.32,208.07) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text transform='translate(40.32,431.11) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text transform='translate(40.32,362.48) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>50</text>
+<text transform='translate(40.32,293.85) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>75</text>
+<text transform='translate(40.32,225.22) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
 <text x='374.40' y='573.12' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='19.34px' lengthAdjust='spacingAndGlyphs'>m/z</text>
 <text transform='translate(11.52,266.40) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='64.70px' lengthAdjust='spacingAndGlyphs'>intensity [%]</text>
 <text x='374.40' y='25.92' text-anchor='middle' style='font-size: 10.20px; font-family: sans;' textLength='340.78px' lengthAdjust='spacingAndGlyphs'>mzspec/testfile.mzML/scan: 1/rt: 2345/charge: 2/sequence: HIGFEGDSIGR</text>
 </g>
 <g clip-path='url(#cpNTcuNjB8NjkxLjIwfDE0LjQwfDUxOC40MA==)'>
-<text transform='translate(596.11,324.73) rotate(-90)' style='font-size: 10.80px; font-family: sans;' textLength='45.35px' lengthAdjust='spacingAndGlyphs'>1.96e+06</text>
+<text transform='translate(596.11,335.03) rotate(-90)' style='font-size: 10.80px; font-family: sans;' textLength='45.35px' lengthAdjust='spacingAndGlyphs'>1.96e+06</text>
 <line x1='57.60' y1='499.73' x2='691.20' y2='499.73' style='stroke-width: 0.75; stroke: #737373;' />
 </g>
 <defs>

--- a/tests/testthat/_snaps/plotSpectraPTM/one-ptm-deltamz-true.svg
+++ b/tests/testthat/_snaps/plotSpectraPTM/one-ptm-deltamz-true.svg
@@ -25,64 +25,64 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpNDcuODF8MzM2LjEwfDExLjk1fDQzMi4xOQ==)'>
-<text x='68.48' y='400.35' text-anchor='middle' style='font-size: 9.96px; fill: #006400; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>a2</text>
-<text x='76.10' y='402.59' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b2</text>
-<text x='91.61' y='387.08' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b3</text>
-<text x='131.64' y='363.63' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b4</text>
-<text x='182.27' y='396.75' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b6</text>
-<text x='219.55' y='393.40' text-anchor='middle' style='font-size: 9.96px; fill: #006400; font-family: sans;' textLength='16.06px' lengthAdjust='spacingAndGlyphs'>z7_</text>
-<text x='229.09' y='284.71' text-anchor='middle' style='font-size: 9.96px; fill: #8B0000; font-family: sans;' textLength='10.52px' lengthAdjust='spacingAndGlyphs'>y7</text>
-<text x='259.03' y='402.83' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b8</text>
-<text x='284.63' y='167.46' text-anchor='middle' style='font-size: 9.96px; fill: #8B0000; font-family: sans;' textLength='10.52px' lengthAdjust='spacingAndGlyphs'>y9</text>
-<text x='297.70' y='380.87' text-anchor='middle' style='font-size: 9.96px; fill: #006400; font-family: sans;' textLength='16.62px' lengthAdjust='spacingAndGlyphs'>a10</text>
-<text x='310.51' y='244.63' text-anchor='middle' style='font-size: 9.96px; fill: #8B0000; font-family: sans;' textLength='21.60px' lengthAdjust='spacingAndGlyphs'>y10_</text>
-<text x='142.56' y='91.74' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.20px' lengthAdjust='spacingAndGlyphs'>H</text>
-<text x='152.44' y='91.74' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='2.77px' lengthAdjust='spacingAndGlyphs'>I</text>
-<text x='162.32' y='91.75' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.75px' lengthAdjust='spacingAndGlyphs'>G</text>
-<text x='172.20' y='91.74' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='6.08px' lengthAdjust='spacingAndGlyphs'>F</text>
-<text x='182.07' y='91.74' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='6.65px' lengthAdjust='spacingAndGlyphs'>E</text>
-<text x='191.95' y='91.75' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.75px' lengthAdjust='spacingAndGlyphs'>G</text>
-<text x='201.83' y='91.74' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.20px' lengthAdjust='spacingAndGlyphs'>D</text>
-<text x='211.71' y='90.89' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='12.18px' lengthAdjust='spacingAndGlyphs'>[S]</text>
-<text x='221.59' y='91.74' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='2.77px' lengthAdjust='spacingAndGlyphs'>I</text>
-<text x='231.46' y='91.75' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.75px' lengthAdjust='spacingAndGlyphs'>G</text>
-<text x='241.34' y='91.74' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.20px' lengthAdjust='spacingAndGlyphs'>R</text>
-<line x1='157.38' y1='88.32' x2='157.38' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='167.26' y1='88.32' x2='167.26' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='177.14' y1='88.32' x2='177.14' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='196.89' y1='88.32' x2='196.89' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='216.65' y1='88.32' x2='216.65' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='154.91' y1='112.63' x2='157.38' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='164.79' y1='112.63' x2='167.26' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='174.67' y1='112.63' x2='177.14' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='194.42' y1='112.63' x2='196.89' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='214.18' y1='112.63' x2='216.65' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
-<text x='153.68' y='121.55' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>2</text>
-<text x='163.55' y='121.55' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>3</text>
-<text x='173.43' y='121.55' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>4</text>
-<text x='193.19' y='121.55' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>6</text>
-<text x='212.94' y='121.55' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>8</text>
-<line x1='157.38' y1='88.32' x2='157.38' y2='72.10' style='stroke-width: 1.50; stroke: #8B0000;' />
-<line x1='177.14' y1='88.32' x2='177.14' y2='72.10' style='stroke-width: 1.50; stroke: #8B0000;' />
-<line x1='159.85' y1='64.00' x2='157.38' y2='72.10' style='stroke-width: 1.50; stroke: #8B0000;' />
-<line x1='179.60' y1='64.00' x2='177.14' y2='72.10' style='stroke-width: 1.50; stroke: #8B0000;' />
-<text x='161.08' y='61.94' text-anchor='middle' style='font-size: 9.96px; fill: #8B0000; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>9</text>
-<text x='180.84' y='61.94' text-anchor='middle' style='font-size: 9.96px; fill: #8B0000; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>7</text>
-<line x1='68.48' y1='416.63' x2='68.48' y2='406.33' style='stroke-width: 0.75; stroke: #006400;' />
-<line x1='76.10' y1='416.63' x2='76.10' y2='408.56' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='91.61' y1='416.63' x2='91.61' y2='393.05' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='131.64' y1='416.63' x2='131.64' y2='369.60' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='172.20' y1='416.63' x2='172.20' y2='381.76' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='182.27' y1='416.63' x2='182.27' y2='402.73' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='189.33' y1='416.63' x2='189.33' y2='411.79' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='219.55' y1='416.63' x2='219.55' y2='399.38' style='stroke-width: 0.75; stroke: #006400;' />
-<line x1='229.09' y1='416.63' x2='229.09' y2='290.69' style='stroke-width: 0.75; stroke: #8B0000;' />
-<line x1='259.03' y1='416.63' x2='259.03' y2='408.81' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='278.65' y1='416.63' x2='278.65' y2='409.43' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='284.63' y1='416.63' x2='284.63' y2='173.43' style='stroke-width: 0.75; stroke: #8B0000;' />
-<line x1='297.70' y1='416.63' x2='297.70' y2='386.85' style='stroke-width: 0.75; stroke: #006400;' />
-<line x1='310.51' y1='416.63' x2='310.51' y2='250.61' style='stroke-width: 0.75; stroke: #8B0000;' />
-<line x1='315.43' y1='416.63' x2='315.43' y2='411.58' style='stroke-width: 0.75; stroke: #666666;' />
+<text x='68.48' y='400.96' text-anchor='middle' style='font-size: 9.96px; fill: #006400; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>a2</text>
+<text x='76.10' y='403.06' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b2</text>
+<text x='91.61' y='388.46' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b3</text>
+<text x='131.64' y='366.39' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b4</text>
+<text x='182.27' y='397.57' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b6</text>
+<text x='219.55' y='394.42' text-anchor='middle' style='font-size: 9.96px; fill: #006400; font-family: sans;' textLength='16.06px' lengthAdjust='spacingAndGlyphs'>z7_</text>
+<text x='229.09' y='292.12' text-anchor='middle' style='font-size: 9.96px; fill: #8B0000; font-family: sans;' textLength='10.52px' lengthAdjust='spacingAndGlyphs'>y7</text>
+<text x='259.03' y='403.29' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b8</text>
+<text x='284.63' y='181.76' text-anchor='middle' style='font-size: 9.96px; fill: #8B0000; font-family: sans;' textLength='10.52px' lengthAdjust='spacingAndGlyphs'>y9</text>
+<text x='297.70' y='382.62' text-anchor='middle' style='font-size: 9.96px; fill: #006400; font-family: sans;' textLength='16.62px' lengthAdjust='spacingAndGlyphs'>a10</text>
+<text x='310.51' y='254.40' text-anchor='middle' style='font-size: 9.96px; fill: #8B0000; font-family: sans;' textLength='21.60px' lengthAdjust='spacingAndGlyphs'>y10_</text>
+<text x='142.56' y='111.05' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.20px' lengthAdjust='spacingAndGlyphs'>H</text>
+<text x='152.44' y='111.05' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='2.77px' lengthAdjust='spacingAndGlyphs'>I</text>
+<text x='162.32' y='111.06' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.75px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='172.20' y='111.05' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='6.08px' lengthAdjust='spacingAndGlyphs'>F</text>
+<text x='182.07' y='111.05' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='6.65px' lengthAdjust='spacingAndGlyphs'>E</text>
+<text x='191.95' y='111.06' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.75px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='201.83' y='111.05' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.20px' lengthAdjust='spacingAndGlyphs'>D</text>
+<text x='211.71' y='110.20' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='12.18px' lengthAdjust='spacingAndGlyphs'>[S]</text>
+<text x='221.59' y='111.05' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='2.77px' lengthAdjust='spacingAndGlyphs'>I</text>
+<text x='231.46' y='111.06' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.75px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='241.34' y='111.05' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.20px' lengthAdjust='spacingAndGlyphs'>R</text>
+<line x1='157.38' y1='107.63' x2='157.38' y2='122.89' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='167.26' y1='107.63' x2='167.26' y2='122.89' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='177.14' y1='107.63' x2='177.14' y2='122.89' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='196.89' y1='107.63' x2='196.89' y2='122.89' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='216.65' y1='107.63' x2='216.65' y2='122.89' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='154.91' y1='130.52' x2='157.38' y2='122.89' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='164.79' y1='130.52' x2='167.26' y2='122.89' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='174.67' y1='130.52' x2='177.14' y2='122.89' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='194.42' y1='130.52' x2='196.89' y2='122.89' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='214.18' y1='130.52' x2='216.65' y2='122.89' style='stroke-width: 1.50; stroke: #00008B;' />
+<text x='153.68' y='139.43' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='163.55' y='139.43' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='173.43' y='139.43' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='193.19' y='139.43' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='212.94' y='139.43' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>8</text>
+<line x1='157.38' y1='107.63' x2='157.38' y2='92.37' style='stroke-width: 1.50; stroke: #8B0000;' />
+<line x1='177.14' y1='107.63' x2='177.14' y2='92.37' style='stroke-width: 1.50; stroke: #8B0000;' />
+<line x1='159.85' y1='84.74' x2='157.38' y2='92.37' style='stroke-width: 1.50; stroke: #8B0000;' />
+<line x1='179.60' y1='84.74' x2='177.14' y2='92.37' style='stroke-width: 1.50; stroke: #8B0000;' />
+<text x='161.08' y='82.68' text-anchor='middle' style='font-size: 9.96px; fill: #8B0000; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>9</text>
+<text x='180.84' y='82.68' text-anchor='middle' style='font-size: 9.96px; fill: #8B0000; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>7</text>
+<line x1='68.48' y1='416.63' x2='68.48' y2='406.93' style='stroke-width: 0.75; stroke: #006400;' />
+<line x1='76.10' y1='416.63' x2='76.10' y2='409.04' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='91.61' y1='416.63' x2='91.61' y2='394.44' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='131.64' y1='416.63' x2='131.64' y2='372.37' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='172.20' y1='416.63' x2='172.20' y2='383.81' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='182.27' y1='416.63' x2='182.27' y2='403.55' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='189.33' y1='416.63' x2='189.33' y2='412.07' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='219.55' y1='416.63' x2='219.55' y2='400.40' style='stroke-width: 0.75; stroke: #006400;' />
+<line x1='229.09' y1='416.63' x2='229.09' y2='298.10' style='stroke-width: 0.75; stroke: #8B0000;' />
+<line x1='259.03' y1='416.63' x2='259.03' y2='409.27' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='278.65' y1='416.63' x2='278.65' y2='409.85' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='284.63' y1='416.63' x2='284.63' y2='187.74' style='stroke-width: 0.75; stroke: #8B0000;' />
+<line x1='297.70' y1='416.63' x2='297.70' y2='388.60' style='stroke-width: 0.75; stroke: #006400;' />
+<line x1='310.51' y1='416.63' x2='310.51' y2='260.38' style='stroke-width: 0.75; stroke: #8B0000;' />
+<line x1='315.43' y1='416.63' x2='315.43' y2='411.87' style='stroke-width: 0.75; stroke: #666666;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <line x1='62.18' y1='416.63' x2='334.32' y2='416.63' style='stroke-width: 0.75; stroke: #737373;' />
@@ -147,17 +147,17 @@
 <line x1='317.99' y1='416.63' x2='317.99' y2='419.51' style='stroke-width: 0.75; stroke: #A6A6A6;' />
 <line x1='323.43' y1='416.63' x2='323.43' y2='419.51' style='stroke-width: 0.75; stroke: #A6A6A6;' />
 <line x1='328.87' y1='416.63' x2='328.87' y2='419.51' style='stroke-width: 0.75; stroke: #A6A6A6;' />
-<line x1='47.81' y1='416.63' x2='47.81' y2='173.43' style='stroke-width: 0.75;' />
+<line x1='47.81' y1='416.63' x2='47.81' y2='187.74' style='stroke-width: 0.75;' />
 <line x1='47.81' y1='416.63' x2='42.04' y2='416.63' style='stroke-width: 0.75;' />
-<line x1='47.81' y1='355.83' x2='42.04' y2='355.83' style='stroke-width: 0.75;' />
-<line x1='47.81' y1='295.03' x2='42.04' y2='295.03' style='stroke-width: 0.75;' />
-<line x1='47.81' y1='234.23' x2='42.04' y2='234.23' style='stroke-width: 0.75;' />
-<line x1='47.81' y1='173.43' x2='42.04' y2='173.43' style='stroke-width: 0.75;' />
+<line x1='47.81' y1='359.41' x2='42.04' y2='359.41' style='stroke-width: 0.75;' />
+<line x1='47.81' y1='302.18' x2='42.04' y2='302.18' style='stroke-width: 0.75;' />
+<line x1='47.81' y1='244.96' x2='42.04' y2='244.96' style='stroke-width: 0.75;' />
+<line x1='47.81' y1='187.74' x2='42.04' y2='187.74' style='stroke-width: 0.75;' />
 <text transform='translate(33.47,416.63) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text transform='translate(33.47,355.83) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>25</text>
-<text transform='translate(33.47,295.03) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>50</text>
-<text transform='translate(33.47,234.23) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>75</text>
-<text transform='translate(33.47,173.43) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='16.62px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text transform='translate(33.47,359.41) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text transform='translate(33.47,302.18) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>50</text>
+<text transform='translate(33.47,244.96) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>75</text>
+<text transform='translate(33.47,187.74) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='16.62px' lengthAdjust='spacingAndGlyphs'>100</text>
 </g>
 <defs>
   <clipPath id='cpMC4wMHwzNjAuMDB8MC4wMHw0ODAuMDA='>
@@ -172,7 +172,7 @@
 <text x='191.95' y='21.51' text-anchor='middle' style='font-size: 10.20px; font-family: sans;' textLength='377.65px' lengthAdjust='spacingAndGlyphs'>mzspec/testfile.mzML/scan: 1/rt: 2345/charge: 2/sequence: HIGFEGDS[79.996]IGR</text>
 </g>
 <g clip-path='url(#cpNDcuODF8MzM2LjEwfDExLjk1fDQzMi4xOQ==)'>
-<text transform='translate(293.86,270.71) rotate(-90)' style='font-size: 8.96px; font-family: sans;' textLength='37.64px' lengthAdjust='spacingAndGlyphs'>1.96e+06</text>
+<text transform='translate(293.86,279.29) rotate(-90)' style='font-size: 8.96px; font-family: sans;' textLength='37.64px' lengthAdjust='spacingAndGlyphs'>1.96e+06</text>
 <line x1='47.81' y1='416.63' x2='336.10' y2='416.63' style='stroke-width: 0.75; stroke: #737373;' />
 </g>
 <defs>
@@ -257,54 +257,54 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpNDA3LjgxfDY5Ni4xMHwxMS45NXw0MzIuMTk=)'>
-<text x='428.72' y='400.35' text-anchor='middle' style='font-size: 9.96px; fill: #006400; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>a2</text>
-<text x='436.32' y='402.59' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b2</text>
-<text x='451.81' y='387.08' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b3</text>
-<text x='491.76' y='363.63' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b4</text>
-<text x='532.24' y='375.79' text-anchor='middle' style='font-size: 9.96px; fill: #8B0000; font-family: sans;' textLength='10.52px' lengthAdjust='spacingAndGlyphs'>y6</text>
-<text x='542.29' y='396.75' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b6</text>
-<text x='638.48' y='403.45' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='22.16px' lengthAdjust='spacingAndGlyphs'>b10_</text>
-<text x='502.66' y='91.74' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.20px' lengthAdjust='spacingAndGlyphs'>H</text>
-<text x='512.52' y='91.74' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='2.77px' lengthAdjust='spacingAndGlyphs'>I</text>
-<text x='522.38' y='91.75' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.75px' lengthAdjust='spacingAndGlyphs'>G</text>
-<text x='532.23' y='91.74' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='6.08px' lengthAdjust='spacingAndGlyphs'>F</text>
-<text x='542.09' y='91.74' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='6.65px' lengthAdjust='spacingAndGlyphs'>E</text>
-<text x='551.95' y='91.75' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.75px' lengthAdjust='spacingAndGlyphs'>G</text>
-<text x='561.81' y='91.74' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.20px' lengthAdjust='spacingAndGlyphs'>D</text>
-<text x='571.67' y='91.75' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='6.65px' lengthAdjust='spacingAndGlyphs'>S</text>
-<text x='581.53' y='91.74' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='2.77px' lengthAdjust='spacingAndGlyphs'>I</text>
-<text x='591.39' y='91.75' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.75px' lengthAdjust='spacingAndGlyphs'>G</text>
-<text x='601.25' y='91.74' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.20px' lengthAdjust='spacingAndGlyphs'>R</text>
-<line x1='517.45' y1='88.32' x2='517.45' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='527.30' y1='88.32' x2='527.30' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='537.16' y1='88.32' x2='537.16' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='556.88' y1='88.32' x2='556.88' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='514.98' y1='112.63' x2='517.45' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='524.84' y1='112.63' x2='527.30' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='534.70' y1='112.63' x2='537.16' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='554.42' y1='112.63' x2='556.88' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
-<text x='513.75' y='121.55' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>2</text>
-<text x='523.61' y='121.55' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>3</text>
-<text x='533.47' y='121.55' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>4</text>
-<text x='553.18' y='121.55' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>6</text>
-<line x1='547.02' y1='88.32' x2='547.02' y2='72.10' style='stroke-width: 1.50; stroke: #8B0000;' />
-<line x1='549.49' y1='64.00' x2='547.02' y2='72.10' style='stroke-width: 1.50; stroke: #8B0000;' />
-<text x='550.72' y='61.94' text-anchor='middle' style='font-size: 9.96px; fill: #8B0000; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>6</text>
-<line x1='428.72' y1='416.63' x2='428.72' y2='406.33' style='stroke-width: 0.75; stroke: #006400;' />
-<line x1='436.32' y1='416.63' x2='436.32' y2='408.56' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='451.81' y1='416.63' x2='451.81' y2='393.05' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='491.76' y1='416.63' x2='491.76' y2='369.60' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='532.24' y1='416.63' x2='532.24' y2='381.76' style='stroke-width: 0.75; stroke: #8B0000;' />
-<line x1='542.29' y1='416.63' x2='542.29' y2='402.73' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='549.33' y1='416.63' x2='549.33' y2='411.79' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='579.50' y1='416.63' x2='579.50' y2='399.38' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='589.02' y1='416.63' x2='589.02' y2='290.69' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='618.90' y1='416.63' x2='618.90' y2='408.81' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='638.48' y1='416.63' x2='638.48' y2='409.43' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='644.45' y1='416.63' x2='644.45' y2='173.43' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='657.50' y1='416.63' x2='657.50' y2='386.85' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='670.28' y1='416.63' x2='670.28' y2='250.61' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='675.19' y1='416.63' x2='675.19' y2='411.58' style='stroke-width: 0.75; stroke: #666666;' />
+<text x='428.72' y='400.96' text-anchor='middle' style='font-size: 9.96px; fill: #006400; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>a2</text>
+<text x='436.32' y='403.06' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b2</text>
+<text x='451.81' y='388.46' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b3</text>
+<text x='491.76' y='366.39' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b4</text>
+<text x='532.24' y='377.84' text-anchor='middle' style='font-size: 9.96px; fill: #8B0000; font-family: sans;' textLength='10.52px' lengthAdjust='spacingAndGlyphs'>y6</text>
+<text x='542.29' y='397.57' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b6</text>
+<text x='638.48' y='403.88' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='22.16px' lengthAdjust='spacingAndGlyphs'>b10_</text>
+<text x='502.66' y='111.05' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.20px' lengthAdjust='spacingAndGlyphs'>H</text>
+<text x='512.52' y='111.05' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='2.77px' lengthAdjust='spacingAndGlyphs'>I</text>
+<text x='522.38' y='111.06' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.75px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='532.23' y='111.05' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='6.08px' lengthAdjust='spacingAndGlyphs'>F</text>
+<text x='542.09' y='111.05' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='6.65px' lengthAdjust='spacingAndGlyphs'>E</text>
+<text x='551.95' y='111.06' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.75px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='561.81' y='111.05' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.20px' lengthAdjust='spacingAndGlyphs'>D</text>
+<text x='571.67' y='111.06' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='6.65px' lengthAdjust='spacingAndGlyphs'>S</text>
+<text x='581.53' y='111.05' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='2.77px' lengthAdjust='spacingAndGlyphs'>I</text>
+<text x='591.39' y='111.06' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.75px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='601.25' y='111.05' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.20px' lengthAdjust='spacingAndGlyphs'>R</text>
+<line x1='517.45' y1='107.63' x2='517.45' y2='122.89' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='527.30' y1='107.63' x2='527.30' y2='122.89' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='537.16' y1='107.63' x2='537.16' y2='122.89' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='556.88' y1='107.63' x2='556.88' y2='122.89' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='514.98' y1='130.52' x2='517.45' y2='122.89' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='524.84' y1='130.52' x2='527.30' y2='122.89' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='534.70' y1='130.52' x2='537.16' y2='122.89' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='554.42' y1='130.52' x2='556.88' y2='122.89' style='stroke-width: 1.50; stroke: #00008B;' />
+<text x='513.75' y='139.43' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='523.61' y='139.43' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='533.47' y='139.43' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='553.18' y='139.43' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>6</text>
+<line x1='547.02' y1='107.63' x2='547.02' y2='92.37' style='stroke-width: 1.50; stroke: #8B0000;' />
+<line x1='549.49' y1='84.74' x2='547.02' y2='92.37' style='stroke-width: 1.50; stroke: #8B0000;' />
+<text x='550.72' y='82.68' text-anchor='middle' style='font-size: 9.96px; fill: #8B0000; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>6</text>
+<line x1='428.72' y1='416.63' x2='428.72' y2='406.93' style='stroke-width: 0.75; stroke: #006400;' />
+<line x1='436.32' y1='416.63' x2='436.32' y2='409.04' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='451.81' y1='416.63' x2='451.81' y2='394.44' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='491.76' y1='416.63' x2='491.76' y2='372.37' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='532.24' y1='416.63' x2='532.24' y2='383.81' style='stroke-width: 0.75; stroke: #8B0000;' />
+<line x1='542.29' y1='416.63' x2='542.29' y2='403.55' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='549.33' y1='416.63' x2='549.33' y2='412.07' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='579.50' y1='416.63' x2='579.50' y2='400.40' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='589.02' y1='416.63' x2='589.02' y2='298.10' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='618.90' y1='416.63' x2='618.90' y2='409.27' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='638.48' y1='416.63' x2='638.48' y2='409.85' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='644.45' y1='416.63' x2='644.45' y2='187.74' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='657.50' y1='416.63' x2='657.50' y2='388.60' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='670.28' y1='416.63' x2='670.28' y2='260.38' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='675.19' y1='416.63' x2='675.19' y2='411.87' style='stroke-width: 0.75; stroke: #666666;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <line x1='422.43' y1='416.63' x2='694.04' y2='416.63' style='stroke-width: 0.75; stroke: #737373;' />
@@ -369,17 +369,17 @@
 <line x1='677.75' y1='416.63' x2='677.75' y2='419.51' style='stroke-width: 0.75; stroke: #A6A6A6;' />
 <line x1='683.18' y1='416.63' x2='683.18' y2='419.51' style='stroke-width: 0.75; stroke: #A6A6A6;' />
 <line x1='688.61' y1='416.63' x2='688.61' y2='419.51' style='stroke-width: 0.75; stroke: #A6A6A6;' />
-<line x1='407.81' y1='416.63' x2='407.81' y2='173.43' style='stroke-width: 0.75;' />
+<line x1='407.81' y1='416.63' x2='407.81' y2='187.74' style='stroke-width: 0.75;' />
 <line x1='407.81' y1='416.63' x2='402.04' y2='416.63' style='stroke-width: 0.75;' />
-<line x1='407.81' y1='355.83' x2='402.04' y2='355.83' style='stroke-width: 0.75;' />
-<line x1='407.81' y1='295.03' x2='402.04' y2='295.03' style='stroke-width: 0.75;' />
-<line x1='407.81' y1='234.23' x2='402.04' y2='234.23' style='stroke-width: 0.75;' />
-<line x1='407.81' y1='173.43' x2='402.04' y2='173.43' style='stroke-width: 0.75;' />
+<line x1='407.81' y1='359.41' x2='402.04' y2='359.41' style='stroke-width: 0.75;' />
+<line x1='407.81' y1='302.18' x2='402.04' y2='302.18' style='stroke-width: 0.75;' />
+<line x1='407.81' y1='244.96' x2='402.04' y2='244.96' style='stroke-width: 0.75;' />
+<line x1='407.81' y1='187.74' x2='402.04' y2='187.74' style='stroke-width: 0.75;' />
 <text transform='translate(393.47,416.63) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text transform='translate(393.47,355.83) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>25</text>
-<text transform='translate(393.47,295.03) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>50</text>
-<text transform='translate(393.47,234.23) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>75</text>
-<text transform='translate(393.47,173.43) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='16.62px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text transform='translate(393.47,359.41) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text transform='translate(393.47,302.18) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>50</text>
+<text transform='translate(393.47,244.96) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>75</text>
+<text transform='translate(393.47,187.74) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='16.62px' lengthAdjust='spacingAndGlyphs'>100</text>
 </g>
 <defs>
   <clipPath id='cpMzYwLjAwfDcyMC4wMHwwLjAwfDQ4MC4wMA=='>
@@ -394,7 +394,7 @@
 <text x='551.95' y='21.51' text-anchor='middle' style='font-size: 10.20px; font-family: sans;' textLength='340.78px' lengthAdjust='spacingAndGlyphs'>mzspec/testfile.mzML/scan: 1/rt: 2345/charge: 2/sequence: HIGFEGDSIGR</text>
 </g>
 <g clip-path='url(#cpNDA3LjgxfDY5Ni4xMHwxMS45NXw0MzIuMTk=)'>
-<text transform='translate(653.68,270.71) rotate(-90)' style='font-size: 8.96px; font-family: sans;' textLength='37.64px' lengthAdjust='spacingAndGlyphs'>1.96e+06</text>
+<text transform='translate(653.68,279.29) rotate(-90)' style='font-size: 8.96px; font-family: sans;' textLength='37.64px' lengthAdjust='spacingAndGlyphs'>1.96e+06</text>
 <line x1='407.81' y1='416.63' x2='696.10' y2='416.63' style='stroke-width: 0.75; stroke: #737373;' />
 </g>
 <defs>

--- a/tests/testthat/_snaps/plotSpectraPTM/one-ptm-deltamz-true.svg
+++ b/tests/testthat/_snaps/plotSpectraPTM/one-ptm-deltamz-true.svg
@@ -25,64 +25,64 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpNDcuODF8MzM2LjEwfDExLjk1fDQzMi4xOQ==)'>
-<text x='68.48' y='398.88' text-anchor='middle' style='font-size: 9.96px; fill: #006400; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>a2</text>
-<text x='76.10' y='401.43' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b2</text>
-<text x='91.61' y='383.71' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b3</text>
-<text x='131.64' y='356.91' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b4</text>
-<text x='182.27' y='394.77' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b6</text>
-<text x='219.55' y='390.94' text-anchor='middle' style='font-size: 9.96px; fill: #006400; font-family: sans;' textLength='16.06px' lengthAdjust='spacingAndGlyphs'>z7_</text>
-<text x='229.09' y='266.72' text-anchor='middle' style='font-size: 9.96px; fill: #8B0000; font-family: sans;' textLength='10.52px' lengthAdjust='spacingAndGlyphs'>y7</text>
-<text x='259.03' y='401.72' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b8</text>
-<text x='284.63' y='132.72' text-anchor='middle' style='font-size: 9.96px; fill: #8B0000; font-family: sans;' textLength='10.52px' lengthAdjust='spacingAndGlyphs'>y9</text>
-<text x='297.70' y='376.62' text-anchor='middle' style='font-size: 9.96px; fill: #006400; font-family: sans;' textLength='16.62px' lengthAdjust='spacingAndGlyphs'>a10</text>
-<text x='310.51' y='220.92' text-anchor='middle' style='font-size: 9.96px; fill: #8B0000; font-family: sans;' textLength='21.60px' lengthAdjust='spacingAndGlyphs'>y10_</text>
-<text x='110.72' y='86.53' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.20px' lengthAdjust='spacingAndGlyphs'>H</text>
-<text x='126.97' y='86.53' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='2.77px' lengthAdjust='spacingAndGlyphs'>I</text>
-<text x='143.21' y='86.53' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.75px' lengthAdjust='spacingAndGlyphs'>G</text>
-<text x='159.46' y='86.53' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='6.08px' lengthAdjust='spacingAndGlyphs'>F</text>
-<text x='175.71' y='86.53' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='6.65px' lengthAdjust='spacingAndGlyphs'>E</text>
-<text x='191.95' y='86.53' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.75px' lengthAdjust='spacingAndGlyphs'>G</text>
-<text x='208.20' y='86.53' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.20px' lengthAdjust='spacingAndGlyphs'>D</text>
-<text x='224.45' y='85.68' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='12.18px' lengthAdjust='spacingAndGlyphs'>[S]</text>
-<text x='240.69' y='86.53' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='2.77px' lengthAdjust='spacingAndGlyphs'>I</text>
-<text x='256.94' y='86.53' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.75px' lengthAdjust='spacingAndGlyphs'>G</text>
-<text x='273.18' y='86.53' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.20px' lengthAdjust='spacingAndGlyphs'>R</text>
-<line x1='135.09' y1='83.10' x2='135.09' y2='101.63' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='151.34' y1='83.10' x2='151.34' y2='101.63' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='167.58' y1='83.10' x2='167.58' y2='101.63' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='200.08' y1='83.10' x2='200.08' y2='101.63' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='232.57' y1='83.10' x2='232.57' y2='101.63' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='131.03' y1='101.63' x2='135.09' y2='101.63' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='147.27' y1='101.63' x2='151.34' y2='101.63' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='163.52' y1='101.63' x2='167.58' y2='101.63' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='196.01' y1='101.63' x2='200.08' y2='101.63' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='228.51' y1='101.63' x2='232.57' y2='101.63' style='stroke-width: 1.50; stroke: #00008B;' />
-<text x='133.06' y='110.54' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>2</text>
-<text x='149.30' y='110.54' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>3</text>
-<text x='165.55' y='110.54' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>4</text>
-<text x='198.04' y='110.54' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>6</text>
-<text x='230.54' y='110.54' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>8</text>
-<line x1='135.09' y1='83.10' x2='135.09' y2='64.57' style='stroke-width: 1.50; stroke: #8B0000;' />
-<line x1='167.58' y1='83.10' x2='167.58' y2='64.57' style='stroke-width: 1.50; stroke: #8B0000;' />
-<line x1='139.15' y1='64.57' x2='135.09' y2='64.57' style='stroke-width: 1.50; stroke: #8B0000;' />
-<line x1='171.64' y1='64.57' x2='167.58' y2='64.57' style='stroke-width: 1.50; stroke: #8B0000;' />
-<text x='137.12' y='62.52' text-anchor='middle' style='font-size: 9.96px; fill: #8B0000; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>9</text>
-<text x='169.61' y='62.52' text-anchor='middle' style='font-size: 9.96px; fill: #8B0000; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>7</text>
-<line x1='68.48' y1='416.63' x2='68.48' y2='404.86' style='stroke-width: 0.75; stroke: #006400;' />
-<line x1='76.10' y1='416.63' x2='76.10' y2='407.41' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='91.61' y1='416.63' x2='91.61' y2='389.68' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='131.64' y1='416.63' x2='131.64' y2='362.88' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='172.20' y1='416.63' x2='172.20' y2='376.78' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='182.27' y1='416.63' x2='182.27' y2='400.75' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='189.33' y1='416.63' x2='189.33' y2='411.10' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='219.55' y1='416.63' x2='219.55' y2='396.92' style='stroke-width: 0.75; stroke: #006400;' />
-<line x1='229.09' y1='416.63' x2='229.09' y2='272.70' style='stroke-width: 0.75; stroke: #8B0000;' />
-<line x1='259.03' y1='416.63' x2='259.03' y2='407.69' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='278.65' y1='416.63' x2='278.65' y2='408.40' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='284.63' y1='416.63' x2='284.63' y2='138.69' style='stroke-width: 0.75; stroke: #8B0000;' />
-<line x1='297.70' y1='416.63' x2='297.70' y2='382.59' style='stroke-width: 0.75; stroke: #006400;' />
-<line x1='310.51' y1='416.63' x2='310.51' y2='226.89' style='stroke-width: 0.75; stroke: #8B0000;' />
-<line x1='315.43' y1='416.63' x2='315.43' y2='410.86' style='stroke-width: 0.75; stroke: #666666;' />
+<text x='68.48' y='400.35' text-anchor='middle' style='font-size: 9.96px; fill: #006400; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>a2</text>
+<text x='76.10' y='402.59' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b2</text>
+<text x='91.61' y='387.08' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b3</text>
+<text x='131.64' y='363.63' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b4</text>
+<text x='182.27' y='396.75' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b6</text>
+<text x='219.55' y='393.40' text-anchor='middle' style='font-size: 9.96px; fill: #006400; font-family: sans;' textLength='16.06px' lengthAdjust='spacingAndGlyphs'>z7_</text>
+<text x='229.09' y='284.71' text-anchor='middle' style='font-size: 9.96px; fill: #8B0000; font-family: sans;' textLength='10.52px' lengthAdjust='spacingAndGlyphs'>y7</text>
+<text x='259.03' y='402.83' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b8</text>
+<text x='284.63' y='167.46' text-anchor='middle' style='font-size: 9.96px; fill: #8B0000; font-family: sans;' textLength='10.52px' lengthAdjust='spacingAndGlyphs'>y9</text>
+<text x='297.70' y='380.87' text-anchor='middle' style='font-size: 9.96px; fill: #006400; font-family: sans;' textLength='16.62px' lengthAdjust='spacingAndGlyphs'>a10</text>
+<text x='310.51' y='244.63' text-anchor='middle' style='font-size: 9.96px; fill: #8B0000; font-family: sans;' textLength='21.60px' lengthAdjust='spacingAndGlyphs'>y10_</text>
+<text x='142.56' y='91.74' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.20px' lengthAdjust='spacingAndGlyphs'>H</text>
+<text x='152.44' y='91.74' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='2.77px' lengthAdjust='spacingAndGlyphs'>I</text>
+<text x='162.32' y='91.75' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.75px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='172.20' y='91.74' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='6.08px' lengthAdjust='spacingAndGlyphs'>F</text>
+<text x='182.07' y='91.74' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='6.65px' lengthAdjust='spacingAndGlyphs'>E</text>
+<text x='191.95' y='91.75' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.75px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='201.83' y='91.74' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.20px' lengthAdjust='spacingAndGlyphs'>D</text>
+<text x='211.71' y='90.89' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='12.18px' lengthAdjust='spacingAndGlyphs'>[S]</text>
+<text x='221.59' y='91.74' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='2.77px' lengthAdjust='spacingAndGlyphs'>I</text>
+<text x='231.46' y='91.75' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.75px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='241.34' y='91.74' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.20px' lengthAdjust='spacingAndGlyphs'>R</text>
+<line x1='157.38' y1='88.32' x2='157.38' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='167.26' y1='88.32' x2='167.26' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='177.14' y1='88.32' x2='177.14' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='196.89' y1='88.32' x2='196.89' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='216.65' y1='88.32' x2='216.65' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='154.91' y1='112.63' x2='157.38' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='164.79' y1='112.63' x2='167.26' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='174.67' y1='112.63' x2='177.14' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='194.42' y1='112.63' x2='196.89' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='214.18' y1='112.63' x2='216.65' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
+<text x='153.68' y='121.55' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='163.55' y='121.55' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='173.43' y='121.55' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='193.19' y='121.55' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='212.94' y='121.55' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>8</text>
+<line x1='157.38' y1='88.32' x2='157.38' y2='72.10' style='stroke-width: 1.50; stroke: #8B0000;' />
+<line x1='177.14' y1='88.32' x2='177.14' y2='72.10' style='stroke-width: 1.50; stroke: #8B0000;' />
+<line x1='159.85' y1='64.00' x2='157.38' y2='72.10' style='stroke-width: 1.50; stroke: #8B0000;' />
+<line x1='179.60' y1='64.00' x2='177.14' y2='72.10' style='stroke-width: 1.50; stroke: #8B0000;' />
+<text x='161.08' y='61.94' text-anchor='middle' style='font-size: 9.96px; fill: #8B0000; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>9</text>
+<text x='180.84' y='61.94' text-anchor='middle' style='font-size: 9.96px; fill: #8B0000; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>7</text>
+<line x1='68.48' y1='416.63' x2='68.48' y2='406.33' style='stroke-width: 0.75; stroke: #006400;' />
+<line x1='76.10' y1='416.63' x2='76.10' y2='408.56' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='91.61' y1='416.63' x2='91.61' y2='393.05' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='131.64' y1='416.63' x2='131.64' y2='369.60' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='172.20' y1='416.63' x2='172.20' y2='381.76' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='182.27' y1='416.63' x2='182.27' y2='402.73' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='189.33' y1='416.63' x2='189.33' y2='411.79' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='219.55' y1='416.63' x2='219.55' y2='399.38' style='stroke-width: 0.75; stroke: #006400;' />
+<line x1='229.09' y1='416.63' x2='229.09' y2='290.69' style='stroke-width: 0.75; stroke: #8B0000;' />
+<line x1='259.03' y1='416.63' x2='259.03' y2='408.81' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='278.65' y1='416.63' x2='278.65' y2='409.43' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='284.63' y1='416.63' x2='284.63' y2='173.43' style='stroke-width: 0.75; stroke: #8B0000;' />
+<line x1='297.70' y1='416.63' x2='297.70' y2='386.85' style='stroke-width: 0.75; stroke: #006400;' />
+<line x1='310.51' y1='416.63' x2='310.51' y2='250.61' style='stroke-width: 0.75; stroke: #8B0000;' />
+<line x1='315.43' y1='416.63' x2='315.43' y2='411.58' style='stroke-width: 0.75; stroke: #666666;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <line x1='62.18' y1='416.63' x2='334.32' y2='416.63' style='stroke-width: 0.75; stroke: #737373;' />
@@ -147,17 +147,17 @@
 <line x1='317.99' y1='416.63' x2='317.99' y2='419.51' style='stroke-width: 0.75; stroke: #A6A6A6;' />
 <line x1='323.43' y1='416.63' x2='323.43' y2='419.51' style='stroke-width: 0.75; stroke: #A6A6A6;' />
 <line x1='328.87' y1='416.63' x2='328.87' y2='419.51' style='stroke-width: 0.75; stroke: #A6A6A6;' />
-<line x1='47.81' y1='416.63' x2='47.81' y2='138.69' style='stroke-width: 0.75;' />
+<line x1='47.81' y1='416.63' x2='47.81' y2='173.43' style='stroke-width: 0.75;' />
 <line x1='47.81' y1='416.63' x2='42.04' y2='416.63' style='stroke-width: 0.75;' />
-<line x1='47.81' y1='347.14' x2='42.04' y2='347.14' style='stroke-width: 0.75;' />
-<line x1='47.81' y1='277.66' x2='42.04' y2='277.66' style='stroke-width: 0.75;' />
-<line x1='47.81' y1='208.18' x2='42.04' y2='208.18' style='stroke-width: 0.75;' />
-<line x1='47.81' y1='138.69' x2='42.04' y2='138.69' style='stroke-width: 0.75;' />
+<line x1='47.81' y1='355.83' x2='42.04' y2='355.83' style='stroke-width: 0.75;' />
+<line x1='47.81' y1='295.03' x2='42.04' y2='295.03' style='stroke-width: 0.75;' />
+<line x1='47.81' y1='234.23' x2='42.04' y2='234.23' style='stroke-width: 0.75;' />
+<line x1='47.81' y1='173.43' x2='42.04' y2='173.43' style='stroke-width: 0.75;' />
 <text transform='translate(33.47,416.63) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text transform='translate(33.47,347.14) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>25</text>
-<text transform='translate(33.47,277.66) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>50</text>
-<text transform='translate(33.47,208.18) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>75</text>
-<text transform='translate(33.47,138.69) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='16.62px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text transform='translate(33.47,355.83) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text transform='translate(33.47,295.03) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>50</text>
+<text transform='translate(33.47,234.23) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>75</text>
+<text transform='translate(33.47,173.43) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='16.62px' lengthAdjust='spacingAndGlyphs'>100</text>
 </g>
 <defs>
   <clipPath id='cpMC4wMHwzNjAuMDB8MC4wMHw0ODAuMDA='>
@@ -169,10 +169,10 @@
 <text transform='translate(9.56,222.07) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='53.70px' lengthAdjust='spacingAndGlyphs'>intensity [%]</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<text x='191.95' y='9.56' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='444.29px' lengthAdjust='spacingAndGlyphs'>mzspec/testfile.mzML/scan: 1/rt: 2345/charge: 2/sequence: HIGFEGDS[79.996]IGR</text>
+<text x='191.95' y='21.51' text-anchor='middle' style='font-size: 10.20px; font-family: sans;' textLength='377.65px' lengthAdjust='spacingAndGlyphs'>mzspec/testfile.mzML/scan: 1/rt: 2345/charge: 2/sequence: HIGFEGDS[79.996]IGR</text>
 </g>
 <g clip-path='url(#cpNDcuODF8MzM2LjEwfDExLjk1fDQzMi4xOQ==)'>
-<text transform='translate(293.86,249.87) rotate(-90)' style='font-size: 8.96px; font-family: sans;' textLength='37.64px' lengthAdjust='spacingAndGlyphs'>1.96e+06</text>
+<text transform='translate(293.86,270.71) rotate(-90)' style='font-size: 8.96px; font-family: sans;' textLength='37.64px' lengthAdjust='spacingAndGlyphs'>1.96e+06</text>
 <line x1='47.81' y1='416.63' x2='336.10' y2='416.63' style='stroke-width: 0.75; stroke: #737373;' />
 </g>
 <defs>
@@ -257,54 +257,54 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpNDA3LjgxfDY5Ni4xMHwxMS45NXw0MzIuMTk=)'>
-<text x='428.72' y='398.88' text-anchor='middle' style='font-size: 9.96px; fill: #006400; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>a2</text>
-<text x='436.32' y='401.43' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b2</text>
-<text x='451.81' y='383.71' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b3</text>
-<text x='491.76' y='356.91' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b4</text>
-<text x='532.24' y='370.80' text-anchor='middle' style='font-size: 9.96px; fill: #8B0000; font-family: sans;' textLength='10.52px' lengthAdjust='spacingAndGlyphs'>y6</text>
-<text x='542.29' y='394.77' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b6</text>
-<text x='638.48' y='402.43' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='22.16px' lengthAdjust='spacingAndGlyphs'>b10_</text>
-<text x='470.88' y='86.53' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.20px' lengthAdjust='spacingAndGlyphs'>H</text>
-<text x='487.09' y='86.53' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='2.77px' lengthAdjust='spacingAndGlyphs'>I</text>
-<text x='503.31' y='86.53' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.75px' lengthAdjust='spacingAndGlyphs'>G</text>
-<text x='519.52' y='86.53' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='6.08px' lengthAdjust='spacingAndGlyphs'>F</text>
-<text x='535.74' y='86.53' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='6.65px' lengthAdjust='spacingAndGlyphs'>E</text>
-<text x='551.95' y='86.53' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.75px' lengthAdjust='spacingAndGlyphs'>G</text>
-<text x='568.17' y='86.53' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.20px' lengthAdjust='spacingAndGlyphs'>D</text>
-<text x='584.38' y='86.53' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='6.65px' lengthAdjust='spacingAndGlyphs'>S</text>
-<text x='600.60' y='86.53' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='2.77px' lengthAdjust='spacingAndGlyphs'>I</text>
-<text x='616.81' y='86.53' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.75px' lengthAdjust='spacingAndGlyphs'>G</text>
-<text x='633.03' y='86.53' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.20px' lengthAdjust='spacingAndGlyphs'>R</text>
-<line x1='495.20' y1='83.10' x2='495.20' y2='101.63' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='511.41' y1='83.10' x2='511.41' y2='101.63' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='527.63' y1='83.10' x2='527.63' y2='101.63' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='560.06' y1='83.10' x2='560.06' y2='101.63' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='491.14' y1='101.63' x2='495.20' y2='101.63' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='507.36' y1='101.63' x2='511.41' y2='101.63' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='523.58' y1='101.63' x2='527.63' y2='101.63' style='stroke-width: 1.50; stroke: #00008B;' />
-<line x1='556.01' y1='101.63' x2='560.06' y2='101.63' style='stroke-width: 1.50; stroke: #00008B;' />
-<text x='493.17' y='110.54' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>2</text>
-<text x='509.39' y='110.54' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>3</text>
-<text x='525.60' y='110.54' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>4</text>
-<text x='558.03' y='110.54' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>6</text>
-<line x1='543.84' y1='83.10' x2='543.84' y2='64.57' style='stroke-width: 1.50; stroke: #8B0000;' />
-<line x1='547.90' y1='64.57' x2='543.84' y2='64.57' style='stroke-width: 1.50; stroke: #8B0000;' />
-<text x='545.87' y='62.52' text-anchor='middle' style='font-size: 9.96px; fill: #8B0000; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>6</text>
-<line x1='428.72' y1='416.63' x2='428.72' y2='404.86' style='stroke-width: 0.75; stroke: #006400;' />
-<line x1='436.32' y1='416.63' x2='436.32' y2='407.41' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='451.81' y1='416.63' x2='451.81' y2='389.68' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='491.76' y1='416.63' x2='491.76' y2='362.88' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='532.24' y1='416.63' x2='532.24' y2='376.78' style='stroke-width: 0.75; stroke: #8B0000;' />
-<line x1='542.29' y1='416.63' x2='542.29' y2='400.75' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='549.33' y1='416.63' x2='549.33' y2='411.10' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='579.50' y1='416.63' x2='579.50' y2='396.92' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='589.02' y1='416.63' x2='589.02' y2='272.70' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='618.90' y1='416.63' x2='618.90' y2='407.69' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='638.48' y1='416.63' x2='638.48' y2='408.40' style='stroke-width: 0.75; stroke: #00008B;' />
-<line x1='644.45' y1='416.63' x2='644.45' y2='138.69' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='657.50' y1='416.63' x2='657.50' y2='382.59' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='670.28' y1='416.63' x2='670.28' y2='226.89' style='stroke-width: 0.75; stroke: #666666;' />
-<line x1='675.19' y1='416.63' x2='675.19' y2='410.86' style='stroke-width: 0.75; stroke: #666666;' />
+<text x='428.72' y='400.35' text-anchor='middle' style='font-size: 9.96px; fill: #006400; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>a2</text>
+<text x='436.32' y='402.59' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b2</text>
+<text x='451.81' y='387.08' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b3</text>
+<text x='491.76' y='363.63' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b4</text>
+<text x='532.24' y='375.79' text-anchor='middle' style='font-size: 9.96px; fill: #8B0000; font-family: sans;' textLength='10.52px' lengthAdjust='spacingAndGlyphs'>y6</text>
+<text x='542.29' y='396.75' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>b6</text>
+<text x='638.48' y='403.45' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='22.16px' lengthAdjust='spacingAndGlyphs'>b10_</text>
+<text x='502.66' y='91.74' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.20px' lengthAdjust='spacingAndGlyphs'>H</text>
+<text x='512.52' y='91.74' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='2.77px' lengthAdjust='spacingAndGlyphs'>I</text>
+<text x='522.38' y='91.75' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.75px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='532.23' y='91.74' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='6.08px' lengthAdjust='spacingAndGlyphs'>F</text>
+<text x='542.09' y='91.74' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='6.65px' lengthAdjust='spacingAndGlyphs'>E</text>
+<text x='551.95' y='91.75' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.75px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='561.81' y='91.74' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.20px' lengthAdjust='spacingAndGlyphs'>D</text>
+<text x='571.67' y='91.75' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='6.65px' lengthAdjust='spacingAndGlyphs'>S</text>
+<text x='581.53' y='91.74' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='2.77px' lengthAdjust='spacingAndGlyphs'>I</text>
+<text x='591.39' y='91.75' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.75px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='601.25' y='91.74' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='7.20px' lengthAdjust='spacingAndGlyphs'>R</text>
+<line x1='517.45' y1='88.32' x2='517.45' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='527.30' y1='88.32' x2='527.30' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='537.16' y1='88.32' x2='537.16' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='556.88' y1='88.32' x2='556.88' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='514.98' y1='112.63' x2='517.45' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='524.84' y1='112.63' x2='527.30' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='534.70' y1='112.63' x2='537.16' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='554.42' y1='112.63' x2='556.88' y2='104.53' style='stroke-width: 1.50; stroke: #00008B;' />
+<text x='513.75' y='121.55' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='523.61' y='121.55' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='533.47' y='121.55' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='553.18' y='121.55' text-anchor='middle' style='font-size: 9.96px; fill: #00008B; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>6</text>
+<line x1='547.02' y1='88.32' x2='547.02' y2='72.10' style='stroke-width: 1.50; stroke: #8B0000;' />
+<line x1='549.49' y1='64.00' x2='547.02' y2='72.10' style='stroke-width: 1.50; stroke: #8B0000;' />
+<text x='550.72' y='61.94' text-anchor='middle' style='font-size: 9.96px; fill: #8B0000; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>6</text>
+<line x1='428.72' y1='416.63' x2='428.72' y2='406.33' style='stroke-width: 0.75; stroke: #006400;' />
+<line x1='436.32' y1='416.63' x2='436.32' y2='408.56' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='451.81' y1='416.63' x2='451.81' y2='393.05' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='491.76' y1='416.63' x2='491.76' y2='369.60' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='532.24' y1='416.63' x2='532.24' y2='381.76' style='stroke-width: 0.75; stroke: #8B0000;' />
+<line x1='542.29' y1='416.63' x2='542.29' y2='402.73' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='549.33' y1='416.63' x2='549.33' y2='411.79' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='579.50' y1='416.63' x2='579.50' y2='399.38' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='589.02' y1='416.63' x2='589.02' y2='290.69' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='618.90' y1='416.63' x2='618.90' y2='408.81' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='638.48' y1='416.63' x2='638.48' y2='409.43' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='644.45' y1='416.63' x2='644.45' y2='173.43' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='657.50' y1='416.63' x2='657.50' y2='386.85' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='670.28' y1='416.63' x2='670.28' y2='250.61' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='675.19' y1='416.63' x2='675.19' y2='411.58' style='stroke-width: 0.75; stroke: #666666;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <line x1='422.43' y1='416.63' x2='694.04' y2='416.63' style='stroke-width: 0.75; stroke: #737373;' />
@@ -369,17 +369,17 @@
 <line x1='677.75' y1='416.63' x2='677.75' y2='419.51' style='stroke-width: 0.75; stroke: #A6A6A6;' />
 <line x1='683.18' y1='416.63' x2='683.18' y2='419.51' style='stroke-width: 0.75; stroke: #A6A6A6;' />
 <line x1='688.61' y1='416.63' x2='688.61' y2='419.51' style='stroke-width: 0.75; stroke: #A6A6A6;' />
-<line x1='407.81' y1='416.63' x2='407.81' y2='138.69' style='stroke-width: 0.75;' />
+<line x1='407.81' y1='416.63' x2='407.81' y2='173.43' style='stroke-width: 0.75;' />
 <line x1='407.81' y1='416.63' x2='402.04' y2='416.63' style='stroke-width: 0.75;' />
-<line x1='407.81' y1='347.14' x2='402.04' y2='347.14' style='stroke-width: 0.75;' />
-<line x1='407.81' y1='277.66' x2='402.04' y2='277.66' style='stroke-width: 0.75;' />
-<line x1='407.81' y1='208.18' x2='402.04' y2='208.18' style='stroke-width: 0.75;' />
-<line x1='407.81' y1='138.69' x2='402.04' y2='138.69' style='stroke-width: 0.75;' />
+<line x1='407.81' y1='355.83' x2='402.04' y2='355.83' style='stroke-width: 0.75;' />
+<line x1='407.81' y1='295.03' x2='402.04' y2='295.03' style='stroke-width: 0.75;' />
+<line x1='407.81' y1='234.23' x2='402.04' y2='234.23' style='stroke-width: 0.75;' />
+<line x1='407.81' y1='173.43' x2='402.04' y2='173.43' style='stroke-width: 0.75;' />
 <text transform='translate(393.47,416.63) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='5.54px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text transform='translate(393.47,347.14) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>25</text>
-<text transform='translate(393.47,277.66) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>50</text>
-<text transform='translate(393.47,208.18) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>75</text>
-<text transform='translate(393.47,138.69) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='16.62px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text transform='translate(393.47,355.83) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text transform='translate(393.47,295.03) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>50</text>
+<text transform='translate(393.47,234.23) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='11.08px' lengthAdjust='spacingAndGlyphs'>75</text>
+<text transform='translate(393.47,173.43) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='16.62px' lengthAdjust='spacingAndGlyphs'>100</text>
 </g>
 <defs>
   <clipPath id='cpMzYwLjAwfDcyMC4wMHwwLjAwfDQ4MC4wMA=='>
@@ -391,10 +391,10 @@
 <text transform='translate(369.56,222.07) rotate(-90)' text-anchor='middle' style='font-size: 9.96px; font-family: sans;' textLength='53.70px' lengthAdjust='spacingAndGlyphs'>intensity [%]</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<text x='551.95' y='9.56' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='400.92px' lengthAdjust='spacingAndGlyphs'>mzspec/testfile.mzML/scan: 1/rt: 2345/charge: 2/sequence: HIGFEGDSIGR</text>
+<text x='551.95' y='21.51' text-anchor='middle' style='font-size: 10.20px; font-family: sans;' textLength='340.78px' lengthAdjust='spacingAndGlyphs'>mzspec/testfile.mzML/scan: 1/rt: 2345/charge: 2/sequence: HIGFEGDSIGR</text>
 </g>
 <g clip-path='url(#cpNDA3LjgxfDY5Ni4xMHwxMS45NXw0MzIuMTk=)'>
-<text transform='translate(653.68,249.87) rotate(-90)' style='font-size: 8.96px; font-family: sans;' textLength='37.64px' lengthAdjust='spacingAndGlyphs'>1.96e+06</text>
+<text transform='translate(653.68,270.71) rotate(-90)' style='font-size: 8.96px; font-family: sans;' textLength='37.64px' lengthAdjust='spacingAndGlyphs'>1.96e+06</text>
 <line x1='407.81' y1='416.63' x2='696.10' y2='416.63' style='stroke-width: 0.75; stroke: #737373;' />
 </g>
 <defs>

--- a/tests/testthat/test_plotSpectraPTM.R
+++ b/tests/testthat/test_plotSpectraPTM.R
@@ -21,7 +21,7 @@ test_that("plotSpectraPTM works with deltaMz = TRUE", {
 
     # We're using fixed colors here for reproducibility
     expect_doppelganger(
-        "deltaMz_true",
+        "deltaMz-true",
         function() {
             plotSpectraPTM(
                 spectra,
@@ -51,7 +51,7 @@ test_that("plotSpectraPTM works with deltaMz = FALSE", {
 
     # We're using fixed colors here for reproducibility
     expect_doppelganger(
-        "deltaMz_false",
+        "deltaMz-false",
         function() {
             plotSpectraPTM(
                 spectra,
@@ -81,7 +81,7 @@ test_that("plotSpectraPTM works with variable modifications", {
 
     # We're using fixed colors here for reproducibility
     expect_doppelganger(
-        "one_ptm_deltaMz_true",
+        "one-ptm-deltaMz-true",
         function() {
             plotSpectraPTM(
                 spectra,
@@ -112,7 +112,7 @@ test_that("plotSpectraPTM works with different col", {
 
     # We're using fixed colors here for reproducibility
     expect_doppelganger(
-        "diff_col",
+        "diff-col",
         function() {
             plotSpectraPTM(
                 spectra,

--- a/tests/testthat/test_plotSpectraPTM.R
+++ b/tests/testthat/test_plotSpectraPTM.R
@@ -1,7 +1,6 @@
 #' # each base::graphics plot function must be wrapped by an anonymous function
 #' # that could be called by `vdiffr::expect_doppelganger()`
 #' Run devtools::test_active_file(file = "tests/testthat/test_plotSpectraPTM.R")
-library(vdiffr)
 
 test_that("plotSpectraPTM works with deltaMz = TRUE", {
     sp <- DataFrame(
@@ -63,36 +62,36 @@ test_that("plotSpectraPTM works with deltaMz = FALSE", {
     )
 })
 
-test_that("plotSpectraPTM works with variable modifications", {
-    sp <- DataFrame(
-        msLevel = 2L,
-        rtime = 2345,
-        sequence = "HIGFEGDSIGR",
-        dataOrigin = "testfile.mzML",
-        scanIndex = 1L,
-        charge = 2L
-    )
-    sp$mz <- list(c(223.1583, 251.15432, 308.168017, 455.24801, 604.30949,
-                    641.30842, 667.2244, 778.30164, 813.34935, 923.350391,
-                    995.45281, 1017.43394, 1065.46197, 1112.5069, 1130.5874))
-    sp$intensity <- list(c(83000, 65000, 190000, 379000, 281000, 112000, 39000,
-                           139000, 1015000, 63000, 58000, 1960000, 240000,
-                           1338000, 40700))
-    spectra <- Spectra(sp)
-
-    # We're using fixed colors here for reproducibility
-    expect_doppelganger(
-        "one-ptm-deltaMz-true",
-        function() {
-            plotSpectraPTM(
-                spectra,
-                type = c("a", "b", "c", "x", "y", "z"),
-                variable_modifications = c(S = 79.996),
-                deltaMz = TRUE
-            )
-        }
-    )
-})
+# test_that("plotSpectraPTM works with variable modifications", {
+#     sp <- DataFrame(
+#         msLevel = 2L,
+#         rtime = 2345,
+#         sequence = "HIGFEGDSIGR",
+#         dataOrigin = "testfile.mzML",
+#         scanIndex = 1L,
+#         charge = 2L
+#     )
+#     sp$mz <- list(c(223.1583, 251.15432, 308.168017, 455.24801, 604.30949,
+#                     641.30842, 667.2244, 778.30164, 813.34935, 923.350391,
+#                     995.45281, 1017.43394, 1065.46197, 1112.5069, 1130.5874))
+#     sp$intensity <- list(c(83000, 65000, 190000, 379000, 281000, 112000, 39000,
+#                            139000, 1015000, 63000, 58000, 1960000, 240000,
+#                            1338000, 40700))
+#     spectra <- Spectra(sp)
+# 
+#     # We're using fixed colors here for reproducibility
+#     expect_doppelganger(
+#         "one-ptm-deltaMz-true",
+#         function() {
+#             plotSpectraPTM(
+#                 spectra,
+#                 type = c("a", "b", "c", "x", "y", "z"),
+#                 variable_modifications = c(S = 79.996),
+#                 deltaMz = TRUE
+#             )
+#         }
+#     )
+# })
 
 test_that("plotSpectraPTM works with different col", {
     sp <- DataFrame(

--- a/tests/testthat/test_plotSpectraPTM.R
+++ b/tests/testthat/test_plotSpectraPTM.R
@@ -1,6 +1,7 @@
 #' # each base::graphics plot function must be wrapped by an anonymous function
 #' # that could be called by `vdiffr::expect_doppelganger()`
 #' Run devtools::test_active_file(file = "tests/testthat/test_plotSpectraPTM.R")
+library(vdiffr)
 
 test_that("plotSpectraPTM works with deltaMz = TRUE", {
     sp <- DataFrame(


### PR DESCRIPTION
As a follow-up from #22 , this PR corrects the annotation that were missing.
Some changes were made:

- The title's `cex.main` has been fixed to 1.2 as to never be in the way of the USI and the plot contents.
- The USI stands now in the middle, above the annotations and below the title if there is one
- The annotations have an angled segment instead of a direct corner
- The comments from #22 were adressed

@lgatto @sgibb Thank you for your help and comments, I realise I am giving you reviewers a ton of work last-minute