### PR TITLE
Update makeAdjacencyMatrix to allow splitting protein groups in PSM data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## PSMatch 1.13.2
 
+- Add possibility to split protein groups in PSM data with `makeAdjacencyMatrix`
+(see [issue #30](https://github.com/rformassspectrometry/PSMatch/issues/30))
 - Update Fragments vignette. 
 - Improve `labelFragments()`runtime 
 (see [issue #25](https://github.com/rformassspectrometry/PSMatch/issues/25)).

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 
 - Add possibility to split protein groups in PSM data with `makeAdjacencyMatrix`
 (see [issue #30](https://github.com/rformassspectrometry/PSMatch/issues/30))
+- Removed `showDetails()` from `setMethod("show", "PSM")` as discussed in 
+[issue #30](https://github.com/rformassspectrometry/PSMatch/issues/30)
+
 - Update Fragments vignette. 
 - Improve `labelFragments()`runtime 
 (see [issue #25](https://github.com/rformassspectrometry/PSMatch/issues/25)).

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,6 @@
 (see [issue #30](https://github.com/rformassspectrometry/PSMatch/issues/30))
 - Removed `showDetails()` from `setMethod("show", "PSM")` as discussed in 
 [issue #30](https://github.com/rformassspectrometry/PSMatch/issues/30)
-
 - Update Fragments vignette. 
 - Improve `labelFragments()`runtime 
 (see [issue #25](https://github.com/rformassspectrometry/PSMatch/issues/25)).

--- a/R/PSM-class.R
+++ b/R/PSM-class.R
@@ -173,7 +173,7 @@
 ##' psmVariables(psm)
 ##'
 ##' ## no PSM variables set
-##' try(adjacencyMatrix(psm))
+##' try(adjacencyMatrix(psm, split = ";"))
 ##'
 ##' ## set PSM variables
 ##' psm <- PSM(psm, spectrum = "spectrum", peptide = "sequence",
@@ -181,7 +181,7 @@
 ##' psm
 ##' psmVariables(psm)
 ##'
-##' adjacencyMatrix(psm)
+##' adjacencyMatrix(psm, split = ";")
 NULL
 
 

--- a/R/PSM-class.R
+++ b/R/PSM-class.R
@@ -200,20 +200,12 @@ setClass("PSM",
 showDetails <- function(object) {
     .psmVariables <- psmVariables(object)
     n_sp <- length(unique(object[[.psmVariables["spectrum"]]]))
-    n_pe <- length(unique(object[[.psmVariables["peptide"]]]))
-    n_pr <- length(unique(object[[.psmVariables["protein"]]]))
     tabDecoy <- object[[.psmVariables["decoy"]]]
     cat("Spectra:", n_sp, "unique\n")
     cat("  db: ", sum(!tabDecoy), " target, ",
         sum(tabDecoy), " decoy\n", sep = "")
     tabRank <- table(object[[.psmVariables["rank"]]])
     cat("  ranks:", paste0(names(tabRank),":", tabRank), "\n")
-    cat("Peptides: ")
-    mlt <- tapply(object[[psmVariables(object)["protein"]]],
-                  object[[psmVariables(object)["peptide"]]],
-                  function(xx) length(unique(xx)) > 1)
-    cat(sum(!mlt), "unique,", sum(mlt), "multiple\n")
-    cat("Proteins:", n_pr, "\n")
     invisible(NULL)
 }
 
@@ -224,6 +216,8 @@ setMethod("show", "PSM",
                   cl <- paste("Reduced", cl)
               cat(cl, "with", nrow(object), "rows and",
                   ncol(object), "columns.\n")
+              if (!any(is.na(psmVariables(object))) & !isTRUE(reduced(object)) & nrow(object) > 0)
+                  showDetails(object)
               if (ncol(object) <= 4) {
                   cat("names(", ncol(object), "): ",
                       paste(names(object), collapse = " "), "\n",

--- a/R/PSM-class.R
+++ b/R/PSM-class.R
@@ -224,8 +224,6 @@ setMethod("show", "PSM",
                   cl <- paste("Reduced", cl)
               cat(cl, "with", nrow(object), "rows and",
                   ncol(object), "columns.\n")
-              if (!any(is.na(psmVariables(object))) & !isTRUE(reduced(object)) & nrow(object) > 0)
-                  showDetails(object)
               if (ncol(object) <= 4) {
                   cat("names(", ncol(object), "): ",
                       paste(names(object), collapse = " "), "\n",

--- a/R/PSM-class.R
+++ b/R/PSM-class.R
@@ -173,7 +173,7 @@
 ##' psmVariables(psm)
 ##'
 ##' ## no PSM variables set
-##' try(adjacencyMatrix(psm, split = ";"))
+##' try(adjacencyMatrix(psm))
 ##'
 ##' ## set PSM variables
 ##' psm <- PSM(psm, spectrum = "spectrum", peptide = "sequence",
@@ -181,7 +181,7 @@
 ##' psm
 ##' psmVariables(psm)
 ##'
-##' adjacencyMatrix(psm, split = ";")
+##' adjacencyMatrix(psm)
 NULL
 
 

--- a/R/adjacencyMatrix-accessors.R
+++ b/R/adjacencyMatrix-accessors.R
@@ -4,7 +4,7 @@
 ##'
 ##' @rdname PSM
 setMethod("adjacencyMatrix", "PSM",
-          function(object) {
+          function(object, ...) {
               if (is.na(psmVariables(object)[["protein"]]) |
                   is.na(psmVariables(object)[["peptide"]]))
                   stop("Please define the 'protein' and 'peptide' PSM variables.")
@@ -13,14 +13,10 @@ setMethod("adjacencyMatrix", "PSM",
                   stop("PSM variables 'protein' and 'peptide' must be defined.")
               vec <- object[[psmVariables(object)[["protein"]]]]
               names(vec) <- object[[psmVariables(object)[["peptide"]]]]
-              ## NB1: Given that this vector comes from a PSM object,
-              ## we assume that there is no need to split. This would
-              ## not be the case if we used a data.frame with
-              ## quantitative data.
-              ## NB2: Note that we ignore any score here and always
+              ## NB: Note that we ignore any score here and always
               ## return a binary matrix. Use makeAdjacencyMatrix() for
               ## these features.
-              makeAdjacencyMatrix(vec, split = NULL, binary = TRUE)
+              makeAdjacencyMatrix(vec, binary = TRUE, ...)
           })
 
 

--- a/R/adjacencyMatrix-accessors.R
+++ b/R/adjacencyMatrix-accessors.R
@@ -2,6 +2,7 @@
 ##'
 ##' @importFrom ProtGenerics adjacencyMatrix
 ##'
+##' @param ... Additional arguments passed to [makeAdjacencyMatrix()]. 
 ##' @rdname PSM
 setMethod("adjacencyMatrix", "PSM",
           function(object, ...) {

--- a/R/adjacencyMatrix-accessors.R
+++ b/R/adjacencyMatrix-accessors.R
@@ -2,10 +2,9 @@
 ##'
 ##' @importFrom ProtGenerics adjacencyMatrix
 ##'
-##' @param ... Additional arguments passed to [makeAdjacencyMatrix()]. 
 ##' @rdname PSM
 setMethod("adjacencyMatrix", "PSM",
-          function(object, ...) {
+          function(object) {
               if (is.na(psmVariables(object)[["protein"]]) |
                   is.na(psmVariables(object)[["peptide"]]))
                   stop("Please define the 'protein' and 'peptide' PSM variables.")
@@ -17,7 +16,7 @@ setMethod("adjacencyMatrix", "PSM",
               ## NB: Note that we ignore any score here and always
               ## return a binary matrix. Use makeAdjacencyMatrix() for
               ## these features.
-              makeAdjacencyMatrix(vec, binary = TRUE, ...)
+              makeAdjacencyMatrix(vec, binary = TRUE)
           })
 
 

--- a/R/adjacencyMatrix-create.R
+++ b/R/adjacencyMatrix-create.R
@@ -236,7 +236,7 @@ makeAdjacencyMatrix <- function(x, split = ";",
                                 score = psmVariables(x)["score"],
                                 binary = FALSE) {
     if (inherits(x, "PSM")) {
-        adj <- .makeSparseAdjacencyMatrixFromPSM(x, peptide, protein, score, split)
+        adj <- .makeSparseAdjacencyMatrixFromPSM(x, peptide, protein, score)
     } else if (is.character(x)) {
         adj <- .makeSparseAdjacencyMatrixFromChar(x, split)
     } else stop("'x' must be a character or a PSM object.")

--- a/R/adjacencyMatrix-create.R
+++ b/R/adjacencyMatrix-create.R
@@ -109,8 +109,10 @@
 ##'
 ##' ## ----------------------------
 ##' ## PSM object from a data.frame
+##' 
 ##' ## ----------------------------
-##'
+##' ## Case 1: Duplicate identifications
+##' 
 ##' psmdf <- data.frame(psm = paste0("psm", 1:10),
 ##'                     peptide = paste0("pep", c(1, 1, 2, 2, 3, 4, 6, 7, 8, 8)),
 ##'                     protein = paste0("Prot", LETTERS[c(1, 1, 2, 2, 3, 4, 3, 5, 6, 6)]))
@@ -126,7 +128,18 @@
 ##'
 ##' ## Or set binary to TRUE
 ##' makeAdjacencyMatrix(psm, binary = TRUE)
-##'
+##' 
+##' ## ----------------------------
+##' ## Case 2: Protein groups are separated by a semicolon
+##' psmdf <- data.frame(psm = paste0("psm", 1:5),
+##'                     peptide = paste0("pep", c(1, 2, 3, 4, 5)),
+##'                     protein = c("ProtA", "ProtB;ProtD", "ProtA;ProtC", 
+##'                                 "ProtC", "ProtA;ProtC;ProtD"))
+##' psmdf
+##' psm <- PSM(psmdf, peptide = "peptide", protein = "protein")
+##' psm
+##' makeAdjacencyMatrix(psm, split = ";")
+##' 
 ##' ## ----------------------------
 ##' ## PSM object from an mzid file
 ##' ## ----------------------------
@@ -175,7 +188,7 @@
 ##' makeAdjacencyMatrix(psm)
 ##'
 ##  ## --------------------------------------------------------
-##' ## Case 2: sp1 and sp11 match the same peptide (NKAVRTYHEQ)
+##' ## Case 2: sp1 and sp11 match the same peptide (NKAVRTYHEQ) as different PSMs
 ##' psmdf2 <- rbind(psmdf,
 ##'                 data.frame(spectrum = "sp11",
 ##'                            sequence = psmdf$sequence[1],
@@ -193,30 +206,43 @@
 ##' ## Force a binary matrix
 ##' makeAdjacencyMatrix(psm2, binary = TRUE)
 ##'
+##  ## --------------------------------------------------------
+##' ## Case 3: Peptide (NKAVRTYHEQ) stems from multiple proteins (ProtB and 
+##' ## ProtG). They are separated by a semicolon.
+##' psmdf3 <- psmdf
+##' psmdf3[psmdf3$sequence == "NKAVRTYHEQ","protein"] <- "ProtB;ProtG"
+##' psmdf3
+##' psm3 <- PSM(psmdf3, spectrum = "spectrum", peptide = "sequence",
+##'             protein = "protein", decoy = "decoy", rank = "rank")
+##'
+##' ## Now ProtB & ProtG count 2 PSMs each: NKAVRTYHEQ and IYNHSQGFCA & 
+##' ## EDHINCTQWP respectively
+##' makeAdjacencyMatrix(psm3, split = ";")
+##' 
 ##' ## --------------------------------
-##' ## Case 3: set the score PSM values
+##' ## Case 4: set the score PSM values
 ##' psmVariables(psm) ## no score defined
-##' psm3 <- PSM(psm, spectrum = "spectrum", peptide = "sequence",
+##' psm4 <- PSM(psm, spectrum = "spectrum", peptide = "sequence",
 ##'             protein = "protein", decoy = "decoy", rank = "rank",
 ##'             score = "score")
-##' psmVariables(psm3) ## score defined
+##' psmVariables(psm4) ## score defined
 ##'
 ##' ## adjacency matrix with scores
-##' makeAdjacencyMatrix(psm3)
+##' makeAdjacencyMatrix(psm4)
 ##'
 ##' ## Force a binary matrix
-##' makeAdjacencyMatrix(psm3, binary = TRUE)
+##' makeAdjacencyMatrix(psm4, binary = TRUE)
 ##'
 ##' ## ---------------------------------
-##' ## Case 4: scores with multiple PSMs
+##' ## Case 5: scores with multiple PSMs
 ##'
-##' psm4 <- PSM(psm2, spectrum = "spectrum", peptide = "sequence",
+##' psm5 <- PSM(psm2, spectrum = "spectrum", peptide = "sequence",
 ##'             protein = "protein", decoy = "decoy", rank = "rank",
 ##'             score = "score")
 ##'
 ##' ## Now NKAVRTYHEQ/ProtB has a summed score of 0.093 computed as
 ##' ## 0.082 (from sp1) + 0.011 (from sp11)
-##' makeAdjacencyMatrix(psm4)
+##' makeAdjacencyMatrix(psm5)
 makeAdjacencyMatrix <- function(x, split = ";",
                                 peptide = psmVariables(x)["peptide"],
                                 protein = psmVariables(x)["protein"],

--- a/R/adjacencyMatrix-create.R
+++ b/R/adjacencyMatrix-create.R
@@ -12,13 +12,13 @@
 ##' matrix from a `character` or an instance of class [PSM()].
 ##'
 ##' The character is formatted as `x <- c("ProtA", "ProtB", "ProtA;ProtB",
-##' ...)`, as commonly encoutered in proteomics data spreadsheets. It defines
+##' ...)`, as commonly encountered in proteomics data spreadsheets. It defines
 ##' that the first peptide is mapped to protein "ProtA", the second one to
 ##' protein "ProtB", the third one to "ProtA" and "ProtB", and so on. The
 ##' resulting matrix contains as many rows as there are unique peptides and as
 ##' many columns as there are unique protein identifiers in `x`. The columns 
 ##' are named after the protein identifiers and the peptide/protein vector 
-##' names are used to name the matrix rows (retaining only the unique names).
+##' names are used to name the matrix rows (retaining only the unique names). 
 ##'
 ##' The [makePeptideProteinVector()] function does the opposite operation,
 ##' taking an adjacency matrix as input and returning a peptide/protein
@@ -45,6 +45,10 @@
 ##' further be coloured (see the `protColors` and `pepColors` arguments). The
 ##' function invisibly returns the graph `igraph` object for additional tuning
 ##' and/or interactive visualisation using, for example [igraph::tkplot()].
+##' 
+##' Such as illustrated in the examples below, each row/peptide is 
+##' expected to refer to protein groups or individual proteins (groups of 
+##' size 1). These have to be split accordingly.
 ##'
 ##' @param x Either an instance of class `PSM` or a `character`. See
 ##'     example below for details.

--- a/R/describe.R
+++ b/R/describe.R
@@ -72,11 +72,13 @@ NULL
 ##'
 ##' @param object Either an instance of class `Matrix`, [PSM()] or
 ##'     [ConnectedComponents()].
-describeProteins <- function(object) {
+##'     
+##' @param ... Additional arguments passed to [makeAdjacencyMatrix()].
+describeProteins <- function(object, ...) {
     if (is(object, "PSM")) {
-        adj <- makeAdjacencyMatrix(object)
+        adj <- makeAdjacencyMatrix(object, ...)
     } else if (is(object, "ConnectedComponents")) {
-        adj <- adjacencyMatrix(object)
+        adj <- adjacencyMatrix(object, ...)
     } else if (is(object, "Matrix")) {
         adj <- object
     } else stop("Object must be of class 'Matrix', 'PSM' or 'ConnectedComponents'")
@@ -103,11 +105,11 @@ describeProteins <- function(object) {
 ##' @export
 ##'
 ##' @rdname describeProteins
-describePeptides <- function(object) {
+describePeptides <- function(object, ...) {
     if (is(object, "PSM")) {
-        adj <- makeAdjacencyMatrix(object)
+        adj <- makeAdjacencyMatrix(object, ...)
     } else if (is(object, "ConnectedComponents")) {
-        adj <- adjacencyMatrix(object)
+        adj <- adjacencyMatrix(object, ...)
     } else if (is(object, "Matrix")) {
         adj <- object
     } else stop("Object must be of class 'Matrix', 'PSM' or 'ConnectedComponents'")

--- a/R/describe.R
+++ b/R/describe.R
@@ -78,7 +78,7 @@ describeProteins <- function(object, ...) {
     if (is(object, "PSM")) {
         adj <- makeAdjacencyMatrix(object, ...)
     } else if (is(object, "ConnectedComponents")) {
-        adj <- adjacencyMatrix(object, ...)
+        adj <- adjacencyMatrix(object)
     } else if (is(object, "Matrix")) {
         adj <- object
     } else stop("Object must be of class 'Matrix', 'PSM' or 'ConnectedComponents'")
@@ -109,7 +109,7 @@ describePeptides <- function(object, ...) {
     if (is(object, "PSM")) {
         adj <- makeAdjacencyMatrix(object, ...)
     } else if (is(object, "ConnectedComponents")) {
-        adj <- adjacencyMatrix(object, ...)
+        adj <- adjacencyMatrix(object)
     } else if (is(object, "Matrix")) {
         adj <- object
     } else stop("Object must be of class 'Matrix', 'PSM' or 'ConnectedComponents'")

--- a/man/PSM.Rd
+++ b/man/PSM.Rd
@@ -36,7 +36,7 @@ psmVariables(object, which = "all")
 
 reducePSMs(object, k = object[[psmVariables(object)["spectrum"]]])
 
-\S4method{adjacencyMatrix}{PSM}(object)
+\S4method{adjacencyMatrix}{PSM}(object, ...)
 }
 \arguments{
 \item{x}{\code{character()} of mzid file names, an instance of class
@@ -263,7 +263,7 @@ psm
 psmVariables(psm)
 
 ## no PSM variables set
-try(adjacencyMatrix(psm))
+try(adjacencyMatrix(psm, split = ";"))
 
 ## set PSM variables
 psm <- PSM(psm, spectrum = "spectrum", peptide = "sequence",
@@ -271,5 +271,5 @@ psm <- PSM(psm, spectrum = "spectrum", peptide = "sequence",
 psm
 psmVariables(psm)
 
-adjacencyMatrix(psm)
+adjacencyMatrix(psm, split = ";")
 }

--- a/man/PSM.Rd
+++ b/man/PSM.Rd
@@ -90,6 +90,8 @@ returned. See \code{\link[=PSM]{PSM()}} for valid PSM variables.}
 defines the primary key used to reduce \code{x}. This typically
 corresponds to the spectrum identifier. The defauls is to use
 the spectrum PSM variable.}
+
+\item{...}{Additional arguments passed to \code{\link[=makeAdjacencyMatrix]{makeAdjacencyMatrix()}}.}
 }
 \value{
 \code{PSM()} returns a \code{PSM} object.

--- a/man/PSM.Rd
+++ b/man/PSM.Rd
@@ -36,7 +36,7 @@ psmVariables(object, which = "all")
 
 reducePSMs(object, k = object[[psmVariables(object)["spectrum"]]])
 
-\S4method{adjacencyMatrix}{PSM}(object, ...)
+\S4method{adjacencyMatrix}{PSM}(object)
 }
 \arguments{
 \item{x}{\code{character()} of mzid file names, an instance of class
@@ -90,8 +90,6 @@ returned. See \code{\link[=PSM]{PSM()}} for valid PSM variables.}
 defines the primary key used to reduce \code{x}. This typically
 corresponds to the spectrum identifier. The defauls is to use
 the spectrum PSM variable.}
-
-\item{...}{Additional arguments passed to \code{\link[=makeAdjacencyMatrix]{makeAdjacencyMatrix()}}.}
 }
 \value{
 \code{PSM()} returns a \code{PSM} object.

--- a/man/PSM.Rd
+++ b/man/PSM.Rd
@@ -263,7 +263,7 @@ psm
 psmVariables(psm)
 
 ## no PSM variables set
-try(adjacencyMatrix(psm, split = ";"))
+try(adjacencyMatrix(psm))
 
 ## set PSM variables
 psm <- PSM(psm, spectrum = "spectrum", peptide = "sequence",
@@ -271,5 +271,5 @@ psm <- PSM(psm, spectrum = "spectrum", peptide = "sequence",
 psm
 psmVariables(psm)
 
-adjacencyMatrix(psm, split = ";")
+adjacencyMatrix(psm)
 }

--- a/man/adjacencyMatrix.Rd
+++ b/man/adjacencyMatrix.Rd
@@ -102,7 +102,7 @@ described below convert between these two format.
 The \code{\link[=makeAdjacencyMatrix]{makeAdjacencyMatrix()}} function creates a peptide-by-protein adjacency
 matrix from a \code{character} or an instance of class \code{\link[=PSM]{PSM()}}.
 
-The character is formatted as \code{x <- c("ProtA", "ProtB", "ProtA;ProtB", ...)}, as commonly encoutered in proteomics data spreadsheets. It defines
+The character is formatted as \code{x <- c("ProtA", "ProtB", "ProtA;ProtB", ...)}, as commonly encountered in proteomics data spreadsheets. It defines
 that the first peptide is mapped to protein "ProtA", the second one to
 protein "ProtB", the third one to "ProtA" and "ProtB", and so on. The
 resulting matrix contains as many rows as there are unique peptides and as
@@ -135,6 +135,10 @@ function generates a graph modelling the relation between proteins
 further be coloured (see the \code{protColors} and \code{pepColors} arguments). The
 function invisibly returns the graph \code{igraph} object for additional tuning
 and/or interactive visualisation using, for example \code{\link[igraph:tkplot]{igraph::tkplot()}}.
+
+Such as illustrated in the examples below, each row/peptide is
+expected to refer to protein groups or individual proteins (groups of
+size 1). These have to be split accordingly.
 }
 \examples{
 

--- a/man/adjacencyMatrix.Rd
+++ b/man/adjacencyMatrix.Rd
@@ -99,63 +99,42 @@ stored: either as a vector or an adjacency matrix. The functions
 described below convert between these two format.
 }
 \details{
-The \code{\link[=makeAdjacencyMatrix]{makeAdjacencyMatrix()}} function creates a peptide-by-protein
-adjacency matrix from a \code{character} or an instance of class
-\code{\link[=PSM]{PSM()}}.
+The \code{\link[=makeAdjacencyMatrix]{makeAdjacencyMatrix()}} function creates a peptide-by-protein adjacency
+matrix from a \code{character} or an instance of class \code{\link[=PSM]{PSM()}}.
 
-The character is formatted as \code{x <- c("ProtA", "ProtB", "ProtA;ProtB", ...)}, as commonly encoutered in proteomics data
-spreadsheets. It defines that the first peptide is mapped to
-protein "ProtA", the second one to protein "ProtB", the third one
-to "ProtA" and "ProtB", and so on. The resulting matrix contain
-\code{length(x)} rows an as many columns as there are unique protein
-idenifiers in \code{x}. The columns are named after the protein
-idenifiers and the peptide/protein vector namesa are used to name
-to matrix rows (even if these aren't unique).
+The character is formatted as \code{x <- c("ProtA", "ProtB", "ProtA;ProtB", ...)}, as commonly encoutered in proteomics data spreadsheets. It defines
+that the first peptide is mapped to protein "ProtA", the second one to
+protein "ProtB", the third one to "ProtA" and "ProtB", and so on. The
+resulting matrix contains as many rows as there are unique peptides and as
+many columns as there are unique protein identifiers in \code{x}. The columns
+are named after the protein identifiers and the peptide/protein vector
+names are used to name the matrix rows (retaining only the unique names).
 
-The \code{\link[=makePeptideProteinVector]{makePeptideProteinVector()}} function does the opposite
-operation, taking an adjacency matrix as input and retruning a
-peptide/protein vector. The matrix colnames are used to populate
-the vector and the matrix rownames are used to name the vector
-elements.
+The \code{\link[=makePeptideProteinVector]{makePeptideProteinVector()}} function does the opposite operation,
+taking an adjacency matrix as input and returning a peptide/protein
+vector. The matrix colnames are used to populate the vector and the matrix
+rownames are used to name the vector elements.
 
-Note that when creating an adjacency matrix from a PSM object, the
-matrix is not necessarily binary, as multiple PSMs can match the
-same peptide (sequence), such as for example precursors with
-different charge states. A binary matrix can either be generated
-with the \code{binary} argument (setting all non-0 values to 1) or by
-reducing the PSM object accordingly (see example below).
+Note that when creating an adjacency matrix from a PSM object, the matrix is
+not necessarily binary, as multiple PSMs can match the same peptide
+(sequence), such as for example precursors with different charge states. A
+binary matrix can either be generated with the \code{binary} argument (setting
+all non-0 values to 1) or by reducing the PSM object accordingly (see
+example below).
 
 It is also possible to generate adjacency matrices populated with
-identification scores or probabilites by setting the "score" PSM
-variable upon construction of the PSM object (see \code{\link[=PSM]{PSM()}} for
-details). In case multiple PSMs occur, their respective scores get
-summed.
+identification scores or probabilites by setting the "score" PSM variable
+upon construction of the PSM object (see \code{\link[=PSM]{PSM()}} for details). In case
+multiple PSMs occur, their respective scores get summed.
 
-The \code{plotAdjacencyMatrix()} function is useful to visualise small
-adjacency matrices, such as those representing protein groups
-modelled as connected components, as described and illustrated in
-\code{\link[=ConnectedComponents]{ConnectedComponents()}}. The function generates a graph modelling
-the relation between proteins (represented as squares) and
-peptides (represented as circes), which can further be coloured
-(see the \code{protColors} and \code{pepColors} arguments). The function
-invisibly returns the graph \code{igraph} object for additional tuning
-and/or interactive visualisation using, for example
-\code{\link[igraph:tkplot]{igraph::tkplot()}}.
-
-There exists some important differences in the creation of an
-adjacency matrix from a PSM object or a vector, other than the
-input variable itself:
-\itemize{
-\item In a \code{PSM} object, each row (PSM) refers to an \emph{individual}
-proteins; rows/PSMs never refer to a protein group. There is
-thus no need for a \code{split} argument, which is used exclusively
-when creating a matrix from a character.
-\item Conversely, when using protein vectors, such as those
-illustrated in the example below or retrieved from tabular
-quantitative proteomics data, each row/peptide is expected to
-refer to protein groups and individual proteins (groups of size
-1). These have to be split accordingly.
-}
+The \code{plotAdjacencyMatrix()} function is useful to visualise small adjacency
+matrices, such as those representing protein groups modelled as connected
+components, as described and illustrated in \code{\link[=ConnectedComponents]{ConnectedComponents()}}. The
+function generates a graph modelling the relation between proteins
+(represented as squares) and peptides (represented as circes), which can
+further be coloured (see the \code{protColors} and \code{pepColors} arguments). The
+function invisibly returns the graph \code{igraph} object for additional tuning
+and/or interactive visualisation using, for example \code{\link[igraph:tkplot]{igraph::tkplot()}}.
 }
 \examples{
 

--- a/man/adjacencyMatrix.Rd
+++ b/man/adjacencyMatrix.Rd
@@ -159,7 +159,9 @@ identical(prots, vec)
 
 ## ----------------------------
 ## PSM object from a data.frame
+
 ## ----------------------------
+## Case 1: Duplicate identifications
 
 psmdf <- data.frame(psm = paste0("psm", 1:10),
                     peptide = paste0("pep", c(1, 1, 2, 2, 3, 4, 6, 7, 8, 8)),
@@ -176,6 +178,17 @@ makeAdjacencyMatrix(rpsm)
 
 ## Or set binary to TRUE
 makeAdjacencyMatrix(psm, binary = TRUE)
+
+## ----------------------------
+## Case 2: Protein groups are separated by a semicolon
+psmdf <- data.frame(psm = paste0("psm", 1:5),
+                    peptide = paste0("pep", c(1, 2, 3, 4, 5)),
+                    protein = c("ProtA", "ProtB;ProtD", "ProtA;ProtC", 
+                                "ProtC", "ProtA;ProtC;ProtD"))
+psmdf
+psm <- PSM(psmdf, peptide = "peptide", protein = "protein")
+psm
+makeAdjacencyMatrix(psm, split = ";")
 
 ## ----------------------------
 ## PSM object from an mzid file
@@ -224,7 +237,7 @@ psm <- PSM(psmdf, spectrum = "spectrum", peptide = "sequence",
 ## binary matrix
 makeAdjacencyMatrix(psm)
 
-## Case 2: sp1 and sp11 match the same peptide (NKAVRTYHEQ)
+## Case 2: sp1 and sp11 match the same peptide (NKAVRTYHEQ) as different PSMs
 psmdf2 <- rbind(psmdf,
                 data.frame(spectrum = "sp11",
                            sequence = psmdf$sequence[1],
@@ -242,30 +255,42 @@ makeAdjacencyMatrix(psm2)
 ## Force a binary matrix
 makeAdjacencyMatrix(psm2, binary = TRUE)
 
+## Case 3: Peptide (NKAVRTYHEQ) stems from multiple proteins (ProtB and 
+## ProtG). They are separated by a semicolon.
+psmdf3 <- psmdf
+psmdf3[psmdf3$sequence == "NKAVRTYHEQ","protein"] <- "ProtB;ProtG"
+psmdf3
+psm3 <- PSM(psmdf3, spectrum = "spectrum", peptide = "sequence",
+            protein = "protein", decoy = "decoy", rank = "rank")
+
+## Now ProtB & ProtG count 2 PSMs each: NKAVRTYHEQ and IYNHSQGFCA & 
+## EDHINCTQWP respectively
+makeAdjacencyMatrix(psm3, split = ";")
+
 ## --------------------------------
-## Case 3: set the score PSM values
+## Case 4: set the score PSM values
 psmVariables(psm) ## no score defined
-psm3 <- PSM(psm, spectrum = "spectrum", peptide = "sequence",
+psm4 <- PSM(psm, spectrum = "spectrum", peptide = "sequence",
             protein = "protein", decoy = "decoy", rank = "rank",
             score = "score")
-psmVariables(psm3) ## score defined
+psmVariables(psm4) ## score defined
 
 ## adjacency matrix with scores
-makeAdjacencyMatrix(psm3)
+makeAdjacencyMatrix(psm4)
 
 ## Force a binary matrix
-makeAdjacencyMatrix(psm3, binary = TRUE)
+makeAdjacencyMatrix(psm4, binary = TRUE)
 
 ## ---------------------------------
-## Case 4: scores with multiple PSMs
+## Case 5: scores with multiple PSMs
 
-psm4 <- PSM(psm2, spectrum = "spectrum", peptide = "sequence",
+psm5 <- PSM(psm2, spectrum = "spectrum", peptide = "sequence",
             protein = "protein", decoy = "decoy", rank = "rank",
             score = "score")
 
 ## Now NKAVRTYHEQ/ProtB has a summed score of 0.093 computed as
 ## 0.082 (from sp1) + 0.011 (from sp11)
-makeAdjacencyMatrix(psm4)
+makeAdjacencyMatrix(psm5)
 }
 \author{
 Laurent Gatto

--- a/man/describeProteins.Rd
+++ b/man/describeProteins.Rd
@@ -5,13 +5,15 @@
 \alias{describePeptides}
 \title{Describe protein and peptide compositions}
 \usage{
-describeProteins(object)
+describeProteins(object, ...)
 
-describePeptides(object)
+describePeptides(object, ...)
 }
 \arguments{
 \item{object}{Either an instance of class \code{Matrix}, \code{\link[=PSM]{PSM()}} or
 \code{\link[=ConnectedComponents]{ConnectedComponents()}}.}
+
+\item{...}{Additional arguments passed to \code{\link[=makeAdjacencyMatrix]{makeAdjacencyMatrix()}}.}
 }
 \value{
 \code{describePeptides()} invisibly return the table of unique

--- a/tests/testthat/test_describe.R
+++ b/tests/testthat/test_describe.R
@@ -43,3 +43,4 @@ test_that("describeProteins works", {
     ans <- data.frame(t(ans))
     expect_identical(d1, ans)
 })
+

--- a/vignettes/AdjacencyMatrix.Rmd
+++ b/vignettes/AdjacencyMatrix.Rmd
@@ -28,7 +28,7 @@ library("PSMatch")
 
 This vignette is one among several illustrating how to use the
 `PSMatch` package, focusing on the modelling peptide-protein relations
-using adjacency matrices and connected componencts. For a general
+using adjacency matrices and connected components. For a general
 overview of the package, see the `PSMatch` package manual page
 (`?PSMatch`) and references therein.
 
@@ -49,7 +49,7 @@ id
 ```
 
 When identification data is stored as a table, the relation between
-peptides is typically encode in two columns, once containing the
+peptides is typically encoded in two columns, once containing the
 peptide sequences and the second the protein identifiers these
 peptides stem from. Below are the 10 first observations of our
 identification data table.
@@ -73,22 +73,25 @@ adj[1:5, 1:5]
 This matrix models the relation between the `r length(unique(id$sequence))`
 peptides and the `r length(unique(id$DatabaseAccess))` is our identification
 data. These numbers can be verified by checking the number of unique
-peptides sequences and database accession numbers.
+peptides sequences and database accession numbers. For the latter, if the 
+peptide stems from multiple proteins, these proteins are separated by default 
+with a semicolon `;`.
 
 
 ```{r}
 length(unique(id$sequence))
-length(unique(id$DatabaseAccess))
+length(unique(unlist(strsplit(id$DatabaseAccess, ";"))))
 ```
 
 Some values are > 1 because some peptide sequences are observed more
-than oncce, for example carrying different modification or the same
-one at different sites. The adjacency matrix can be made binary by
-setting `madeAdjacencyMatrix(id, binary = TRUE)`.
+than once, for example carrying different modifications or the same
+one at different sites or having different precursor charge states. 
+The adjacency matrix can be made binary by setting 
+`madeAdjacencyMatrix(id, binary = TRUE)`.
 
 This large matrix is too large to be explored manually and is anyway
 not interesting on its own. Subsets of this matrix that define
-proteins defines by a set of peptides (whether shared or unique) is
+proteins defined by a set of peptides (whether shared or unique) is
 relevant. These are represented by subsets of this large matrix named
 connected component. We can easily compute all these connected
 components to produce the multiple smaller and relevant adjacency
@@ -261,7 +264,7 @@ function from the `r Biocpkg("QFeatures")` package.
 basename(f <- msdata::quant(full.names = TRUE))
 (i <- grep("Intensity\\.", names(read.delim(f))))
 library(QFeatures)
-se <- readSummarizedExperiment(f, ecol = i, sep = "\t")
+se <- readSummarizedExperiment(f, quantCols = i, sep = "\t")
 ```
 
 Below, we create a vector of protein groups (not leading razor protein


### PR DESCRIPTION
This PR was created based on issue #30 .

Changes include:
- Adapted `makeAdjacencyMatrix` to allow splitting protein groups in PSM data
- Reformatted unit tests for better testing the presence of identificaiton duplicates and the presence of protein groups
- Corrected documentation
- Corrected vignette (grammatical errors and introducing the use of protein group splitting)

@lgatto 
