### PR TITLE
Correct filterPsmFdr message

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## PSMatch 1.13.2
 
+- Correct `filterPsmFdr` output message
 - Update Fragments vignette. 
 - Improve `labelFragments()`runtime 
 (see [issue #25](https://github.com/rformassspectrometry/PSMatch/issues/25)).

--- a/R/PSM-filter.R
+++ b/R/PSM-filter.R
@@ -169,6 +169,6 @@ filterPsmFdr <- function(x,
     x <- x[x[, fdr] < FDR, ]
     n1 <- nrow(x)
     if (verbose)
-        message("Removed ", n0 - n1, " PSMs with FDR < ", fdr, ".")
+        message("Removed ", n0 - n1, " PSMs with FDR > ", FDR, ".") 
     x
 }


### PR DESCRIPTION
This PR is in response of issue #32 .

The changes only include the corrected version of the output message when `filterPsmFdr()` is used.