### PR TITLE
Add USI parameter to plotSpectraPTM

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## PSMatch 1.13.2
 
+- Add `USI` parameter to `plotSpectraPTM`.
 - Update Fragments vignette. 
 - Improve `labelFragments()`runtime 
 (see [issue #25](https://github.com/rformassspectrometry/PSMatch/issues/25)).

--- a/R/plotSpectra-PTM.R
+++ b/R/plotSpectra-PTM.R
@@ -61,6 +61,9 @@
 ##'
 ##' @param minorTicks `logical(1L)`. If `TRUE`, minor ticks are added to the
 ##'     plots.  Default is set to `TRUE`.
+##' 
+##' @param USI `logical(1L)`. If `TRUE`, the universal spectrum identifier is
+##'     displayed.
 ##'
 ##' @param ... additional parameters to be passed to the `labelFragments()`
 ##'     function.
@@ -142,7 +145,7 @@ plotSpectraPTM <- function(x, deltaMz = TRUE, ppm = 20,
                                    other = "grey40"),
                            labelCex = 1, labelSrt = 0,
                            labelAdj = NULL, labelPos = 3, labelOffset = 0.5,
-                           asp = 1, minorTicks = TRUE,
+                           asp = 1, minorTicks = TRUE, USI = TRUE,
                            ...) {
     if (!("sequence" %in% Spectra::spectraVariables(x))) {
         stop("Missing 'sequence' in Spectra::spectraVariables(x)")
@@ -177,7 +180,7 @@ plotSpectraPTM <- function(x, deltaMz = TRUE, ppm = 20,
                                       labelOffset = labelOffset,
                                       minorTicks = minorTicks,
                                       deltaMzData = deltaMzData[[i]],
-                                      ppm = ppm)
+                                      ppm = ppm, USI = USI)
     }
 }
 
@@ -199,17 +202,18 @@ plotSpectraPTM <- function(x, deltaMz = TRUE, ppm = 20,
 ##'
 ##' @noRd
 .plot_single_spectrum_PTM <- function(x, xlab = "m/z", ylab = "intensity",
-                                          xlim = numeric(),
-                                          ylim = numeric(), main = character(),
-                                          col = c(y = "darkred",
-                                                  b = "darkblue",
-                                                  acxy = "darkgreen",
-                                                  other = "grey40"),
-                                          labels = list(),
-                                          labelCol = col, labelCex = 1, labelSrt = 0,
-                                          labelAdj = NULL, labelPos = 3,
-                                          labelOffset = 0.5, minorTicks = TRUE,
-                                          ppm = 20, deltaMzData = NULL) {
+                                      xlim = numeric(),
+                                      ylim = numeric(), main = character(),
+                                      col = c(y = "darkred",
+                                              b = "darkblue",
+                                              acxy = "darkgreen",
+                                              other = "grey40"),
+                                      labels = list(),
+                                      labelCol = col, labelCex = 1, labelSrt = 0,
+                                      labelAdj = NULL, labelPos = 3,
+                                      labelOffset = 0.5, minorTicks = TRUE,
+                                      ppm = 20, deltaMzData = NULL,
+                                      USI = TRUE) {
     v <- peaksData(x)[[1L]]
     mzs <- v[, "mz"]
     ints <- v[, "intensity"]
@@ -302,7 +306,7 @@ plotSpectraPTM <- function(x, deltaMz = TRUE, ppm = 20,
         "/peptide: ", peptide_sequence
     )
     
-    mtext(subtxt, line = -1, cex = 0.9)
+    if (USI) mtext(subtxt, line = -1, cex = 0.9)
     
     base_peak <- which.max(abs(ints))
     text(mzs[base_peak], ints[base_peak] * 0.60,

--- a/man/adjacencyMatrix.Rd
+++ b/man/adjacencyMatrix.Rd
@@ -99,62 +99,54 @@ stored: either as a vector or an adjacency matrix. The functions
 described below convert between these two format.
 }
 \details{
-The \code{\link[=makeAdjacencyMatrix]{makeAdjacencyMatrix()}} function creates a peptide-by-protein
-adjacency matrix from a \code{character} or an instance of class
-\code{\link[=PSM]{PSM()}}.
+The \code{\link[=makeAdjacencyMatrix]{makeAdjacencyMatrix()}} function creates a peptide-by-protein adjacency
+matrix from a \code{character} or an instance of class \code{\link[=PSM]{PSM()}}.
 
-The character is formatted as \code{x <- c("ProtA", "ProtB", "ProtA;ProtB", ...)}, as commonly encoutered in proteomics data
-spreadsheets. It defines that the first peptide is mapped to
-protein "ProtA", the second one to protein "ProtB", the third one
-to "ProtA" and "ProtB", and so on. The resulting matrix contain
-\code{length(x)} rows an as many columns as there are unique protein
-idenifiers in \code{x}. The columns are named after the protein
-idenifiers and the peptide/protein vector namesa are used to name
-to matrix rows (even if these aren't unique).
+The character is formatted as \code{x <- c("ProtA", "ProtB", "ProtA;ProtB", ...)}, as commonly encoutered in proteomics data spreadsheets. It defines
+that the first peptide is mapped to protein "ProtA", the second one to
+protein "ProtB", the third one to "ProtA" and "ProtB", and so on. The
+resulting matrix contains \code{length(x)} rows and as many columns as there are
+unique protein idenifiers in \code{x}. The columns are named after the protein
+identifiers and the peptide/protein vector names are used to name to matrix
+rows (even if these aren't unique).
 
-The \code{\link[=makePeptideProteinVector]{makePeptideProteinVector()}} function does the opposite
-operation, taking an adjacency matrix as input and retruning a
-peptide/protein vector. The matrix colnames are used to populate
-the vector and the matrix rownames are used to name the vector
-elements.
+The \code{\link[=makePeptideProteinVector]{makePeptideProteinVector()}} function does the opposite operation,
+taking an adjacency matrix as input and retruning a peptide/protein
+vector. The matrix colnames are used to populate the vector and the matrix
+rownames are used to name the vector elements.
 
-Note that when creating an adjacency matrix from a PSM object, the
-matrix is not necessarily binary, as multiple PSMs can match the
-same peptide (sequence), such as for example precursors with
-different charge states. A binary matrix can either be generated
-with the \code{binary} argument (setting all non-0 values to 1) or by
-reducing the PSM object accordingly (see example below).
+Note that when creating an adjacency matrix from a PSM object, the matrix is
+not necessarily binary, as multiple PSMs can match the same peptide
+(sequence), such as for example precursors with different charge states. A
+binary matrix can either be generated with the \code{binary} argument (setting
+all non-0 values to 1) or by reducing the PSM object accordingly (see
+example below).
 
 It is also possible to generate adjacency matrices populated with
-identification scores or probabilites by setting the "score" PSM
-variable upon construction of the PSM object (see \code{\link[=PSM]{PSM()}} for
-details). In case multiple PSMs occur, their respective scores get
-summed.
+identification scores or probabilites by setting the "score" PSM variable
+upon construction of the PSM object (see \code{\link[=PSM]{PSM()}} for details). In case
+multiple PSMs occur, their respective scores get summed.
 
-The \code{plotAdjacencyMatrix()} function is useful to visualise small
-adjacency matrices, such as those representing protein groups
-modelled as connected components, as described and illustrated in
-\code{\link[=ConnectedComponents]{ConnectedComponents()}}. The function generates a graph modelling
-the relation between proteins (represented as squares) and
-peptides (represented as circes), which can further be coloured
-(see the \code{protColors} and \code{pepColors} arguments). The function
-invisibly returns the graph \code{igraph} object for additional tuning
-and/or interactive visualisation using, for example
-\code{\link[igraph:tkplot]{igraph::tkplot()}}.
+The \code{plotAdjacencyMatrix()} function is useful to visualise small adjacency
+matrices, such as those representing protein groups modelled as connected
+components, as described and illustrated in \code{\link[=ConnectedComponents]{ConnectedComponents()}}. The
+function generates a graph modelling the relation between proteins
+(represented as squares) and peptides (represented as circes), which can
+further be coloured (see the \code{protColors} and \code{pepColors} arguments). The
+function invisibly returns the graph \code{igraph} object for additional tuning
+and/or interactive visualisation using, for example \code{\link[igraph:tkplot]{igraph::tkplot()}}.
 
-There exists some important differences in the creation of an
-adjacency matrix from a PSM object or a vector, other than the
-input variable itself:
+There exists some important differences in the creation of an adjacency
+matrix from a PSM object or a vector, other than the input variable itself:
 \itemize{
-\item In a \code{PSM} object, each row (PSM) refers to an \emph{individual}
-proteins; rows/PSMs never refer to a protein group. There is
-thus no need for a \code{split} argument, which is used exclusively
-when creating a matrix from a character.
-\item Conversely, when using protein vectors, such as those
-illustrated in the example below or retrieved from tabular
-quantitative proteomics data, each row/peptide is expected to
-refer to protein groups and individual proteins (groups of size
-1). These have to be split accordingly.
+\item In a \code{PSM} object, each row (PSM) refers to an \emph{individual} proteins;
+rows/PSMs never refer to a protein group. There is thus no need for a
+\code{split} argument, which is used exclusively when creating a matrix from a
+character.
+\item Conversely, when using protein vectors, such as those illustrated in the
+example below or retrieved from tabular quantitative proteomics data, each
+row/peptide is expected to refer to protein groups or individual proteins
+(groups of size 1). These have to be split accordingly.
 }
 }
 \examples{

--- a/man/adjacencyMatrix.Rd
+++ b/man/adjacencyMatrix.Rd
@@ -99,54 +99,62 @@ stored: either as a vector or an adjacency matrix. The functions
 described below convert between these two format.
 }
 \details{
-The \code{\link[=makeAdjacencyMatrix]{makeAdjacencyMatrix()}} function creates a peptide-by-protein adjacency
-matrix from a \code{character} or an instance of class \code{\link[=PSM]{PSM()}}.
+The \code{\link[=makeAdjacencyMatrix]{makeAdjacencyMatrix()}} function creates a peptide-by-protein
+adjacency matrix from a \code{character} or an instance of class
+\code{\link[=PSM]{PSM()}}.
 
-The character is formatted as \code{x <- c("ProtA", "ProtB", "ProtA;ProtB", ...)}, as commonly encoutered in proteomics data spreadsheets. It defines
-that the first peptide is mapped to protein "ProtA", the second one to
-protein "ProtB", the third one to "ProtA" and "ProtB", and so on. The
-resulting matrix contains \code{length(x)} rows and as many columns as there are
-unique protein idenifiers in \code{x}. The columns are named after the protein
-identifiers and the peptide/protein vector names are used to name to matrix
-rows (even if these aren't unique).
+The character is formatted as \code{x <- c("ProtA", "ProtB", "ProtA;ProtB", ...)}, as commonly encoutered in proteomics data
+spreadsheets. It defines that the first peptide is mapped to
+protein "ProtA", the second one to protein "ProtB", the third one
+to "ProtA" and "ProtB", and so on. The resulting matrix contain
+\code{length(x)} rows an as many columns as there are unique protein
+idenifiers in \code{x}. The columns are named after the protein
+idenifiers and the peptide/protein vector namesa are used to name
+to matrix rows (even if these aren't unique).
 
-The \code{\link[=makePeptideProteinVector]{makePeptideProteinVector()}} function does the opposite operation,
-taking an adjacency matrix as input and retruning a peptide/protein
-vector. The matrix colnames are used to populate the vector and the matrix
-rownames are used to name the vector elements.
+The \code{\link[=makePeptideProteinVector]{makePeptideProteinVector()}} function does the opposite
+operation, taking an adjacency matrix as input and retruning a
+peptide/protein vector. The matrix colnames are used to populate
+the vector and the matrix rownames are used to name the vector
+elements.
 
-Note that when creating an adjacency matrix from a PSM object, the matrix is
-not necessarily binary, as multiple PSMs can match the same peptide
-(sequence), such as for example precursors with different charge states. A
-binary matrix can either be generated with the \code{binary} argument (setting
-all non-0 values to 1) or by reducing the PSM object accordingly (see
-example below).
+Note that when creating an adjacency matrix from a PSM object, the
+matrix is not necessarily binary, as multiple PSMs can match the
+same peptide (sequence), such as for example precursors with
+different charge states. A binary matrix can either be generated
+with the \code{binary} argument (setting all non-0 values to 1) or by
+reducing the PSM object accordingly (see example below).
 
 It is also possible to generate adjacency matrices populated with
-identification scores or probabilites by setting the "score" PSM variable
-upon construction of the PSM object (see \code{\link[=PSM]{PSM()}} for details). In case
-multiple PSMs occur, their respective scores get summed.
+identification scores or probabilites by setting the "score" PSM
+variable upon construction of the PSM object (see \code{\link[=PSM]{PSM()}} for
+details). In case multiple PSMs occur, their respective scores get
+summed.
 
-The \code{plotAdjacencyMatrix()} function is useful to visualise small adjacency
-matrices, such as those representing protein groups modelled as connected
-components, as described and illustrated in \code{\link[=ConnectedComponents]{ConnectedComponents()}}. The
-function generates a graph modelling the relation between proteins
-(represented as squares) and peptides (represented as circes), which can
-further be coloured (see the \code{protColors} and \code{pepColors} arguments). The
-function invisibly returns the graph \code{igraph} object for additional tuning
-and/or interactive visualisation using, for example \code{\link[igraph:tkplot]{igraph::tkplot()}}.
+The \code{plotAdjacencyMatrix()} function is useful to visualise small
+adjacency matrices, such as those representing protein groups
+modelled as connected components, as described and illustrated in
+\code{\link[=ConnectedComponents]{ConnectedComponents()}}. The function generates a graph modelling
+the relation between proteins (represented as squares) and
+peptides (represented as circes), which can further be coloured
+(see the \code{protColors} and \code{pepColors} arguments). The function
+invisibly returns the graph \code{igraph} object for additional tuning
+and/or interactive visualisation using, for example
+\code{\link[igraph:tkplot]{igraph::tkplot()}}.
 
-There exists some important differences in the creation of an adjacency
-matrix from a PSM object or a vector, other than the input variable itself:
+There exists some important differences in the creation of an
+adjacency matrix from a PSM object or a vector, other than the
+input variable itself:
 \itemize{
-\item In a \code{PSM} object, each row (PSM) refers to an \emph{individual} proteins;
-rows/PSMs never refer to a protein group. There is thus no need for a
-\code{split} argument, which is used exclusively when creating a matrix from a
-character.
-\item Conversely, when using protein vectors, such as those illustrated in the
-example below or retrieved from tabular quantitative proteomics data, each
-row/peptide is expected to refer to protein groups or individual proteins
-(groups of size 1). These have to be split accordingly.
+\item In a \code{PSM} object, each row (PSM) refers to an \emph{individual}
+proteins; rows/PSMs never refer to a protein group. There is
+thus no need for a \code{split} argument, which is used exclusively
+when creating a matrix from a character.
+\item Conversely, when using protein vectors, such as those
+illustrated in the example below or retrieved from tabular
+quantitative proteomics data, each row/peptide is expected to
+refer to protein groups and individual proteins (groups of size
+1). These have to be split accordingly.
 }
 }
 \examples{

--- a/man/plotSpectraPTM.Rd
+++ b/man/plotSpectraPTM.Rd
@@ -21,6 +21,7 @@ plotSpectraPTM(
   labelOffset = 0.5,
   asp = 1,
   minorTicks = TRUE,
+  USI = TRUE,
   ...
 )
 }
@@ -73,6 +74,9 @@ ignored.}
 
 \item{minorTicks}{\code{logical(1L)}. If \code{TRUE}, minor ticks are added to the
 plots.  Default is set to \code{TRUE}.}
+
+\item{USI}{\code{logical(1L)}. If \code{TRUE}, the universal spectrum identifier is
+displayed.}
 
 \item{...}{additional parameters to be passed to the \code{labelFragments()}
 function.}

--- a/tests/testthat/_snaps/plotSpectraPTM/usi-true.svg
+++ b/tests/testthat/_snaps/plotSpectraPTM/usi-true.svg
@@ -1,0 +1,273 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTcuNjB8NjkxLjIwfDE0LjQwfDQyMS4yNQ=='>
+    <rect x='57.60' y='14.40' width='633.60' height='406.85' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTcuNjB8NjkxLjIwfDE0LjQwfDQyMS4yNQ==)'>
+<text x='93.83' y='385.90' text-anchor='middle' style='font-size: 12.00px; fill: #006400; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>a2</text>
+<text x='111.15' y='388.73' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b2</text>
+<text x='146.40' y='369.03' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b3</text>
+<text x='237.35' y='339.23' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b4</text>
+<text x='329.53' y='354.68' text-anchor='middle' style='font-size: 12.00px; fill: #8B0000; font-family: sans;' textLength='12.68px' lengthAdjust='spacingAndGlyphs'>y6</text>
+<text x='352.41' y='381.32' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>b6</text>
+<text x='571.40' y='389.84' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='26.70px' lengthAdjust='spacingAndGlyphs'>b10_</text>
+<text x='278.74' y='59.17' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>H</text>
+<text x='297.88' y='59.17' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'>I</text>
+<text x='317.01' y='59.17' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='336.14' y='59.17' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='7.33px' lengthAdjust='spacingAndGlyphs'>F</text>
+<text x='355.27' y='59.17' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>E</text>
+<text x='374.40' y='59.17' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='393.53' y='59.17' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>D</text>
+<text x='412.66' y='59.17' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.01px' lengthAdjust='spacingAndGlyphs'>S</text>
+<text x='431.79' y='59.17' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='3.33px' lengthAdjust='spacingAndGlyphs'>I</text>
+<text x='450.92' y='59.17' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='9.34px' lengthAdjust='spacingAndGlyphs'>G</text>
+<text x='470.06' y='59.17' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='8.67px' lengthAdjust='spacingAndGlyphs'>R</text>
+<line x1='307.44' y1='55.04' x2='307.44' y2='61.81' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='326.57' y1='55.04' x2='326.57' y2='61.81' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='345.70' y1='55.04' x2='345.70' y2='61.81' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='383.97' y1='55.04' x2='383.97' y2='61.81' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='307.44' y1='61.81' x2='302.66' y2='65.20' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='326.57' y1='61.81' x2='321.79' y2='65.20' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='345.70' y1='61.81' x2='340.92' y2='65.20' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='383.97' y1='61.81' x2='379.18' y2='65.20' style='stroke-width: 1.50; stroke: #00008B;' />
+<text x='302.66' y='75.94' text-anchor='end' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='321.79' y='75.94' text-anchor='end' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='340.92' y='75.94' text-anchor='end' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='379.18' y='75.94' text-anchor='end' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<line x1='364.83' y1='55.04' x2='364.83' y2='48.27' style='stroke-width: 1.50; stroke: #8B0000;' />
+<line x1='364.83' y1='48.27' x2='369.62' y2='44.88' style='stroke-width: 1.50; stroke: #8B0000;' />
+<text x='369.62' y='42.40' style='font-size: 12.00px; fill: #8B0000; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>6</text>
+<line x1='93.83' y1='406.18' x2='93.83' y2='393.10' style='stroke-width: 0.75; stroke: #006400;' />
+<line x1='111.15' y1='406.18' x2='111.15' y2='395.93' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='146.40' y1='406.18' x2='146.40' y2='376.23' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='237.35' y1='406.18' x2='237.35' y2='346.43' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='329.53' y1='406.18' x2='329.53' y2='361.88' style='stroke-width: 0.75; stroke: #8B0000;' />
+<line x1='352.41' y1='406.18' x2='352.41' y2='388.52' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='368.43' y1='406.18' x2='368.43' y2='400.03' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='437.12' y1='406.18' x2='437.12' y2='384.27' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='458.79' y1='406.18' x2='458.79' y2='246.17' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='526.82' y1='406.18' x2='526.82' y2='396.25' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='571.40' y1='406.18' x2='571.40' y2='397.04' style='stroke-width: 0.75; stroke: #00008B;' />
+<line x1='584.99' y1='406.18' x2='584.99' y2='97.20' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='614.69' y1='406.18' x2='614.69' y2='368.35' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='643.79' y1='406.18' x2='643.79' y2='195.26' style='stroke-width: 0.75; stroke: #666666;' />
+<line x1='654.97' y1='406.18' x2='654.97' y2='399.76' style='stroke-width: 0.75; stroke: #666666;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<line x1='79.51' y1='406.18' x2='691.20' y2='406.18' style='stroke-width: 0.75; stroke: #737373;' />
+<line x1='79.51' y1='406.18' x2='79.51' y2='413.38' style='stroke-width: 0.75; stroke: #737373;' />
+<line x1='141.35' y1='406.18' x2='141.35' y2='413.38' style='stroke-width: 0.75; stroke: #737373;' />
+<line x1='203.19' y1='406.18' x2='203.19' y2='413.38' style='stroke-width: 0.75; stroke: #737373;' />
+<line x1='265.03' y1='406.18' x2='265.03' y2='413.38' style='stroke-width: 0.75; stroke: #737373;' />
+<line x1='326.86' y1='406.18' x2='326.86' y2='413.38' style='stroke-width: 0.75; stroke: #737373;' />
+<line x1='388.70' y1='406.18' x2='388.70' y2='413.38' style='stroke-width: 0.75; stroke: #737373;' />
+<line x1='450.54' y1='406.18' x2='450.54' y2='413.38' style='stroke-width: 0.75; stroke: #737373;' />
+<line x1='512.38' y1='406.18' x2='512.38' y2='413.38' style='stroke-width: 0.75; stroke: #737373;' />
+<line x1='574.21' y1='406.18' x2='574.21' y2='413.38' style='stroke-width: 0.75; stroke: #737373;' />
+<line x1='636.05' y1='406.18' x2='636.05' y2='413.38' style='stroke-width: 0.75; stroke: #737373;' />
+<text x='79.51' y='432.10' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>200</text>
+<text x='141.35' y='432.10' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>300</text>
+<text x='203.19' y='432.10' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>400</text>
+<text x='265.03' y='432.10' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>500</text>
+<text x='326.86' y='432.10' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>600</text>
+<text x='388.70' y='432.10' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>700</text>
+<text x='450.54' y='432.10' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>800</text>
+<text x='512.38' y='432.10' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>900</text>
+<text x='574.21' y='432.10' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='26.70px' lengthAdjust='spacingAndGlyphs'>1000</text>
+<text x='636.05' y='432.10' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='26.70px' lengthAdjust='spacingAndGlyphs'>1100</text>
+<line x1='91.88' y1='406.18' x2='685.52' y2='406.18' style='stroke-width: 0.75;' />
+<line x1='91.88' y1='406.18' x2='91.88' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='104.25' y1='406.18' x2='104.25' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='116.62' y1='406.18' x2='116.62' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='128.98' y1='406.18' x2='128.98' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='153.72' y1='406.18' x2='153.72' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='166.09' y1='406.18' x2='166.09' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='178.45' y1='406.18' x2='178.45' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='190.82' y1='406.18' x2='190.82' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='215.56' y1='406.18' x2='215.56' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='227.92' y1='406.18' x2='227.92' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='240.29' y1='406.18' x2='240.29' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='252.66' y1='406.18' x2='252.66' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='277.39' y1='406.18' x2='277.39' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='289.76' y1='406.18' x2='289.76' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='302.13' y1='406.18' x2='302.13' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='314.50' y1='406.18' x2='314.50' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='339.23' y1='406.18' x2='339.23' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='351.60' y1='406.18' x2='351.60' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='363.97' y1='406.18' x2='363.97' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='376.33' y1='406.18' x2='376.33' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='401.07' y1='406.18' x2='401.07' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='413.44' y1='406.18' x2='413.44' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='425.80' y1='406.18' x2='425.80' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='438.17' y1='406.18' x2='438.17' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='462.91' y1='406.18' x2='462.91' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='475.27' y1='406.18' x2='475.27' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='487.64' y1='406.18' x2='487.64' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='500.01' y1='406.18' x2='500.01' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='524.74' y1='406.18' x2='524.74' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='537.11' y1='406.18' x2='537.11' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='549.48' y1='406.18' x2='549.48' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='561.85' y1='406.18' x2='561.85' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='586.58' y1='406.18' x2='586.58' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='598.95' y1='406.18' x2='598.95' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='611.32' y1='406.18' x2='611.32' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='623.68' y1='406.18' x2='623.68' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='648.42' y1='406.18' x2='648.42' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='660.79' y1='406.18' x2='660.79' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='673.15' y1='406.18' x2='673.15' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='685.52' y1='406.18' x2='685.52' y2='410.25' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='57.60' y1='406.18' x2='57.60' y2='97.20' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='406.18' x2='50.40' y2='406.18' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='328.94' x2='50.40' y2='328.94' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='251.69' x2='50.40' y2='251.69' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='174.45' x2='50.40' y2='174.45' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='97.20' x2='50.40' y2='97.20' style='stroke-width: 0.75;' />
+<text transform='translate(40.32,406.18) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text transform='translate(40.32,328.94) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text transform='translate(40.32,251.69) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>50</text>
+<text transform='translate(40.32,174.45) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>75</text>
+<text transform='translate(40.32,97.20) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='20.02px' lengthAdjust='spacingAndGlyphs'>100</text>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw0ODAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='480.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw0ODAuMDA=)'>
+<text transform='translate(18.72,217.82) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='64.70px' lengthAdjust='spacingAndGlyphs'>intensity [%]</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='691.20' y='425.57' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='19.34px' lengthAdjust='spacingAndGlyphs'>m/z</text>
+</g>
+<g clip-path='url(#cpNTcuNjB8NjkxLjIwfDE0LjQwfDQyMS4yNQ==)'>
+<text transform='translate(596.11,220.79) rotate(-90)' style='font-size: 10.80px; font-family: sans;' textLength='45.35px' lengthAdjust='spacingAndGlyphs'>1.96e+06</text>
+<line x1='57.60' y1='406.18' x2='691.20' y2='406.18' style='stroke-width: 0.75; stroke: #737373;' />
+</g>
+<defs>
+  <clipPath id='cpNTcuNjB8NjkxLjIwfDQ4Mi44OHw1NjQuMjU='>
+    <rect x='57.60' y='482.88' width='633.60' height='81.37' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTcuNjB8NjkxLjIwfDQ4Mi44OHw1NjQuMjU=)'>
+<line x1='93.83' y1='523.56' x2='93.83' y2='498.50' style='stroke-width: 1.50; stroke: #006400;' />
+<line x1='111.15' y1='523.56' x2='111.15' y2='493.01' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='146.40' y1='523.56' x2='146.40' y2='546.11' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='237.35' y1='523.56' x2='237.35' y2='490.90' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='329.53' y1='523.56' x2='329.53' y2='509.26' style='stroke-width: 1.50; stroke: #8B0000;' />
+<line x1='352.41' y1='523.56' x2='352.41' y2='511.07' style='stroke-width: 1.50; stroke: #00008B;' />
+<line x1='571.40' y1='523.56' x2='571.40' y2='533.56' style='stroke-width: 1.50; stroke: #00008B;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<line x1='57.60' y1='561.24' x2='57.60' y2='485.89' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='561.24' x2='50.40' y2='561.24' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='542.40' x2='50.40' y2='542.40' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='523.56' x2='50.40' y2='523.56' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='504.73' x2='50.40' y2='504.73' style='stroke-width: 0.75;' />
+<line x1='57.60' y1='485.89' x2='50.40' y2='485.89' style='stroke-width: 0.75;' />
+<text transform='translate(40.32,561.24) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='17.34px' lengthAdjust='spacingAndGlyphs'>-20</text>
+<text transform='translate(40.32,523.56) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text transform='translate(40.32,485.89) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>20</text>
+<polygon points='57.60,564.25 691.20,564.25 691.20,482.88 57.60,482.88 ' style='stroke-width: 0.75; fill: none;' />
+</g>
+<g clip-path='url(#cpNTcuNjB8NjkxLjIwfDQ4Mi44OHw1NjQuMjU=)'>
+<circle cx='93.83' cy='498.50' r='1.89' style='stroke-width: 0.75; stroke: #006400; fill: #006400;' />
+<circle cx='111.15' cy='493.01' r='1.89' style='stroke-width: 0.75; stroke: #00008B; fill: #00008B;' />
+<circle cx='146.40' cy='546.11' r='1.89' style='stroke-width: 0.75; stroke: #00008B; fill: #00008B;' />
+<circle cx='237.35' cy='490.90' r='1.89' style='stroke-width: 0.75; stroke: #00008B; fill: #00008B;' />
+<circle cx='329.53' cy='509.26' r='1.89' style='stroke-width: 0.75; stroke: #8B0000; fill: #8B0000;' />
+<circle cx='352.41' cy='511.07' r='1.89' style='stroke-width: 0.75; stroke: #00008B; fill: #00008B;' />
+<circle cx='571.40' cy='533.56' r='1.89' style='stroke-width: 0.75; stroke: #00008B; fill: #00008B;' />
+<line x1='57.60' y1='523.56' x2='691.20' y2='523.56' style='stroke-width: 0.75; stroke: #808080; stroke-dasharray: 4.00,4.00;' />
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NDgwLjAwfDU3Ni4wMA=='>
+    <rect x='0.00' y='480.00' width='720.00' height='96.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NDgwLjAwfDU3Ni4wMA==)'>
+<text transform='translate(12.96,523.56) rotate(-90)' text-anchor='middle' style='font-size: 10.80px; font-family: sans;' textLength='43.82px' lengthAdjust='spacingAndGlyphs'>delta m/z</text>
+<text transform='translate(25.92,523.56) rotate(-90)' text-anchor='middle' style='font-size: 10.80px; font-family: sans;' textLength='27.02px' lengthAdjust='spacingAndGlyphs'>[ppm]</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<line x1='79.51' y1='482.88' x2='691.20' y2='482.88' style='stroke-width: 0.75; stroke: #737373;' />
+<line x1='79.51' y1='482.88' x2='79.51' y2='475.68' style='stroke-width: 0.75; stroke: #737373;' />
+<line x1='141.35' y1='482.88' x2='141.35' y2='475.68' style='stroke-width: 0.75; stroke: #737373;' />
+<line x1='203.19' y1='482.88' x2='203.19' y2='475.68' style='stroke-width: 0.75; stroke: #737373;' />
+<line x1='265.03' y1='482.88' x2='265.03' y2='475.68' style='stroke-width: 0.75; stroke: #737373;' />
+<line x1='326.86' y1='482.88' x2='326.86' y2='475.68' style='stroke-width: 0.75; stroke: #737373;' />
+<line x1='388.70' y1='482.88' x2='388.70' y2='475.68' style='stroke-width: 0.75; stroke: #737373;' />
+<line x1='450.54' y1='482.88' x2='450.54' y2='475.68' style='stroke-width: 0.75; stroke: #737373;' />
+<line x1='512.38' y1='482.88' x2='512.38' y2='475.68' style='stroke-width: 0.75; stroke: #737373;' />
+<line x1='574.21' y1='482.88' x2='574.21' y2='475.68' style='stroke-width: 0.75; stroke: #737373;' />
+<line x1='636.05' y1='482.88' x2='636.05' y2='475.68' style='stroke-width: 0.75; stroke: #737373;' />
+<line x1='91.88' y1='482.88' x2='685.52' y2='482.88' style='stroke-width: 0.75; stroke: #737373;' />
+<line x1='91.88' y1='482.88' x2='91.88' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='104.25' y1='482.88' x2='104.25' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='116.62' y1='482.88' x2='116.62' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='128.98' y1='482.88' x2='128.98' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='153.72' y1='482.88' x2='153.72' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='166.09' y1='482.88' x2='166.09' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='178.45' y1='482.88' x2='178.45' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='190.82' y1='482.88' x2='190.82' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='215.56' y1='482.88' x2='215.56' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='227.92' y1='482.88' x2='227.92' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='240.29' y1='482.88' x2='240.29' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='252.66' y1='482.88' x2='252.66' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='277.39' y1='482.88' x2='277.39' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='289.76' y1='482.88' x2='289.76' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='302.13' y1='482.88' x2='302.13' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='314.50' y1='482.88' x2='314.50' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='339.23' y1='482.88' x2='339.23' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='351.60' y1='482.88' x2='351.60' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='363.97' y1='482.88' x2='363.97' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='376.33' y1='482.88' x2='376.33' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='401.07' y1='482.88' x2='401.07' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='413.44' y1='482.88' x2='413.44' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='425.80' y1='482.88' x2='425.80' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='438.17' y1='482.88' x2='438.17' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='462.91' y1='482.88' x2='462.91' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='475.27' y1='482.88' x2='475.27' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='487.64' y1='482.88' x2='487.64' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='500.01' y1='482.88' x2='500.01' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='524.74' y1='482.88' x2='524.74' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='537.11' y1='482.88' x2='537.11' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='549.48' y1='482.88' x2='549.48' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='561.85' y1='482.88' x2='561.85' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='586.58' y1='482.88' x2='586.58' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='598.95' y1='482.88' x2='598.95' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='611.32' y1='482.88' x2='611.32' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='623.68' y1='482.88' x2='623.68' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='648.42' y1='482.88' x2='648.42' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='660.79' y1='482.88' x2='660.79' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='673.15' y1='482.88' x2='673.15' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+<line x1='685.52' y1='482.88' x2='685.52' y2='478.81' style='stroke-width: 0.75; stroke: #BFBFBF;' />
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng=='>
+    <rect x='59.04' y='59.04' width='630.72' height='443.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
+</g>
+</svg>

--- a/tests/testthat/test_plotSpectraPTM.R
+++ b/tests/testthat/test_plotSpectraPTM.R
@@ -2,24 +2,23 @@
 #' # that could be called by `vdiffr::expect_doppelganger()`
 #' Run devtools::test_active_file(file = "tests/testthat/test_plotSpectraPTM.R")
 
-test_that("plotSpectraPTM works with deltaMz = TRUE", {
-    sp <- DataFrame(
-        msLevel = 2L,
-        rtime = 2345,
-        sequence = "HIGFEGDSIGR",
-        dataOrigin = "testfile.mzML",
-        scanIndex = 1L,
-        charge = 2L
-    )
-    sp$mz <- list(c(223.1583, 251.15432, 308.168017, 455.24801, 604.30949,
-                    641.30842, 667.2244, 778.30164, 813.34935, 923.350391,
-                    995.45281, 1017.43394, 1065.46197, 1112.5069, 1130.5874))
-    sp$intensity <- list(c(83000, 65000, 190000, 379000, 281000, 112000, 39000,
-                           139000, 1015000, 63000, 58000, 1960000, 240000,
-                           1338000, 40700))
-    spectra <- Spectra(sp)
+sp <- DataFrame(
+    msLevel = 2L,
+    rtime = 2345,
+    sequence = "HIGFEGDSIGR",
+    dataOrigin = "testfile.mzML",
+    scanIndex = 1L,
+    charge = 2L
+)
+sp$mz <- list(c(223.1583, 251.15432, 308.168017, 455.24801, 604.30949,
+                641.30842, 667.2244, 778.30164, 813.34935, 923.350391,
+                995.45281, 1017.43394, 1065.46197, 1112.5069, 1130.5874))
+sp$intensity <- list(c(83000, 65000, 190000, 379000, 281000, 112000, 39000,
+                       139000, 1015000, 63000, 58000, 1960000, 240000,
+                       1338000, 40700))
+spectra <- Spectra(sp)
 
-    # We're using fixed colors here for reproducibility
+test_that("plotSpectraPTM works with deltaMz = TRUE", {
     expect_doppelganger(
         "deltaMz-true",
         function() {
@@ -33,23 +32,6 @@ test_that("plotSpectraPTM works with deltaMz = TRUE", {
 })
 
 test_that("plotSpectraPTM works with deltaMz = FALSE", {
-    sp <- DataFrame(
-        msLevel = 2L,
-        rtime = 2345,
-        sequence = "HIGFEGDSIGR",
-        dataOrigin = "testfile.mzML",
-        scanIndex = 1L,
-        charge = 2L
-    )
-    sp$mz <- list(c(223.1583, 251.15432, 308.168017, 455.24801, 604.30949,
-                    641.30842, 667.2244, 778.30164, 813.34935, 923.350391,
-                    995.45281, 1017.43394, 1065.46197, 1112.5069, 1130.5874))
-    sp$intensity <- list(c(83000, 65000, 190000, 379000, 281000, 112000, 39000,
-                           139000, 1015000, 63000, 58000, 1960000, 240000,
-                           1338000, 40700))
-    spectra <- Spectra(sp)
-
-    # We're using fixed colors here for reproducibility
     expect_doppelganger(
         "deltaMz-false",
         function() {
@@ -63,23 +45,6 @@ test_that("plotSpectraPTM works with deltaMz = FALSE", {
 })
 
 # test_that("plotSpectraPTM works with variable modifications", {
-#     sp <- DataFrame(
-#         msLevel = 2L,
-#         rtime = 2345,
-#         sequence = "HIGFEGDSIGR",
-#         dataOrigin = "testfile.mzML",
-#         scanIndex = 1L,
-#         charge = 2L
-#     )
-#     sp$mz <- list(c(223.1583, 251.15432, 308.168017, 455.24801, 604.30949,
-#                     641.30842, 667.2244, 778.30164, 813.34935, 923.350391,
-#                     995.45281, 1017.43394, 1065.46197, 1112.5069, 1130.5874))
-#     sp$intensity <- list(c(83000, 65000, 190000, 379000, 281000, 112000, 39000,
-#                            139000, 1015000, 63000, 58000, 1960000, 240000,
-#                            1338000, 40700))
-#     spectra <- Spectra(sp)
-# 
-#     # We're using fixed colors here for reproducibility
 #     expect_doppelganger(
 #         "one-ptm-deltaMz-true",
 #         function() {
@@ -94,22 +59,6 @@ test_that("plotSpectraPTM works with deltaMz = FALSE", {
 # })
 
 test_that("plotSpectraPTM works with different col", {
-    sp <- DataFrame(
-        msLevel = 2L,
-        rtime = 2345,
-        sequence = "HIGFEGDSIGR",
-        dataOrigin = "testfile.mzML",
-        scanIndex = 1L,
-        charge = 2L
-    )
-    sp$mz <- list(c(223.1583, 251.15432, 308.168017, 455.24801, 604.30949,
-                    641.30842, 667.2244, 778.30164, 813.34935, 923.350391,
-                    995.45281, 1017.43394, 1065.46197, 1112.5069, 1130.5874))
-    sp$intensity <- list(c(83000, 65000, 190000, 379000, 281000, 112000, 39000,
-                           139000, 1015000, 63000, 58000, 1960000, 240000,
-                           1338000, 40700))
-    spectra <- Spectra(sp)
-
     # We're using fixed colors here for reproducibility
     expect_doppelganger(
         "diff-col",
@@ -119,6 +68,19 @@ test_that("plotSpectraPTM works with different col", {
                 col = c(y = "red", b = "blue", acxy = "orange", other = "violet"),
                 type = c("a", "b", "c", "x", "y", "z"),
                 deltaMz = FALSE
+            )
+        }
+    )
+})
+
+test_that("plotSpectraPTM works with USI = FALSE", {
+    expect_doppelganger(
+        "USI-true",
+        function() {
+            plotSpectraPTM(
+                spectra,
+                type = c("a", "b", "c", "x", "y", "z"),
+                USI = FALSE
             )
         }
     )


### PR DESCRIPTION
This pull request changes the `plotSpectraPTM` function in PSMatch by adding a USI parameter that can be TRUE or FALSE. 

By default, it's TRUE, but when FALSE, it removes the the universal spectrum identifier that tends to get in the way when multiple spectra are plotted in a small window (such as vignettes). 
Here's an example of when that happens:

_with USI:_
![image](https://github.com/user-attachments/assets/7cbcf457-df19-4311-b895-0dbd337411be)

_Without USI:_
![image](https://github.com/user-attachments/assets/9fb01e26-10a5-4dfb-ae41-410acd6d5440)

This USI is also less relevant in cases where there are missing variables (such as charge, scan index, ...) in which case it's better to remove it as it brings little information.